### PR TITLE
fix: formatted code into the proper json format

### DIFF
--- a/merged_countries.json
+++ b/merged_countries.json
@@ -1,2387 +1,2387 @@
 [
   {
-    "Country Name": "Aruba",
-    "Country Code": "AW",
-    "Phone Code": "+297",
-    "Flag": "🇦🇼",
-    "Currency": "Guilder",
-    "Currency Code": "AWG",
-    "Currency Symbol": "ƒ"
-  },
-  {
-    "Country Name": "Brunei",
-    "Country Code": "BN",
-    "Phone Code": "+673",
-    "Flag": "🇧🇳",
-    "Currency": "Dollar",
-    "Currency Code": "BND",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Indonesia",
-    "Country Code": "ID",
-    "Phone Code": "+62",
-    "Flag": "🇮🇩",
-    "Currency": "Rupiah",
-    "Currency Code": "IDR",
-    "Currency Symbol": "Rp"
-  },
-  {
-    "Country Name": "San Marino",
-    "Country Code": "SM",
-    "Phone Code": "+378",
-    "Flag": "🇸🇲",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Zimbabwe",
-    "Country Code": "ZW",
-    "Phone Code": "+263",
-    "Flag": "🇿🇼",
-    "Currency": "Dollar",
-    "Currency Code": "ZWL",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Trinidad and Tobago",
-    "Country Code": "TT",
-    "Phone Code": "+1-868",
-    "Flag": "🇹🇹",
-    "Currency": "Dollar",
-    "Currency Code": "TTD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Pitcairn Islands",
-    "Country Code": "PN",
-    "Phone Code": null,
-    "Flag": "🇵🇳",
-    "Currency": "New Zealand dollar",
-    "Currency Code": "NZD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Argentina",
-    "Country Code": "AR",
-    "Phone Code": "+54",
-    "Flag": "🇦🇷",
-    "Currency": "Peso",
-    "Currency Code": "ARS",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Togo",
-    "Country Code": "TG",
-    "Phone Code": "+228",
-    "Flag": "🇹🇬",
-    "Currency": "Franc",
-    "Currency Code": "XOF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Brazil",
-    "Country Code": "BR",
-    "Phone Code": "+55",
-    "Flag": "🇧🇷",
-    "Currency": "Real",
-    "Currency Code": "BRL",
-    "Currency Symbol": "R$"
-  },
-  {
-    "Country Name": "Ethiopia",
-    "Country Code": "ET",
-    "Phone Code": "+251",
-    "Flag": "🇪🇹",
-    "Currency": "Birr",
-    "Currency Code": "ETB",
-    "Currency Symbol": "Br"
-  },
-  {
-    "Country Name": "Grenada",
-    "Country Code": "GD",
-    "Phone Code": "+1-473",
-    "Flag": "🇬🇩",
-    "Currency": "Dollar",
-    "Currency Code": "XCD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Saint Martin",
-    "Country Code": "MF",
-    "Phone Code": "+590",
-    "Flag": "🇲🇫",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "France",
-    "Country Code": "FR",
-    "Phone Code": "+33",
-    "Flag": "🇫🇷",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Tuvalu",
-    "Country Code": "TV",
-    "Phone Code": "+688",
-    "Flag": "🇹🇻",
-    "Currency": "Dollar",
-    "Currency Code": "AUD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Barbados",
-    "Country Code": "BB",
-    "Phone Code": "+1-246",
-    "Flag": "🇧🇧",
-    "Currency": "Dollar",
-    "Currency Code": "BBD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Dominican Republic",
-    "Country Code": "DO",
-    "Phone Code": "+1-809, 1-829, 1-849",
-    "Flag": "🇩🇴",
-    "Currency": "Peso",
-    "Currency Code": "DOP",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Macedonia",
-    "Country Code": "MK",
-    "Phone Code": "+389",
-    "Flag": null,
-    "Currency": "Denar",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Guernsey",
-    "Country Code": "GG",
-    "Phone Code": "+44-1481",
-    "Flag": "🇬🇬",
-    "Currency": "Pound",
-    "Currency Code": "GBP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Madagascar",
-    "Country Code": "MG",
-    "Phone Code": "+261",
-    "Flag": "🇲🇬",
-    "Currency": "Ariary",
-    "Currency Code": "MGA",
-    "Currency Symbol": "Ar"
-  },
-  {
-    "Country Name": "Vanuatu",
-    "Country Code": "VU",
-    "Phone Code": "+678",
-    "Flag": "🇻🇺",
-    "Currency": "Vatu",
-    "Currency Code": "VUV",
-    "Currency Symbol": "Vt"
-  },
-  {
-    "Country Name": "Kenya",
-    "Country Code": "KE",
-    "Phone Code": "+254",
-    "Flag": "🇰🇪",
-    "Currency": "Shilling",
-    "Currency Code": "KES",
-    "Currency Symbol": "Sh"
-  },
-  {
-    "Country Name": "Afghanistan",
-    "Country Code": "AF",
-    "Phone Code": "+93",
-    "Flag": "🇦🇫",
-    "Currency": "Afghani",
-    "Currency Code": "AFN",
-    "Currency Symbol": "؋"
-  },
-  {
-    "Country Name": "Equatorial Guinea",
-    "Country Code": "GQ",
-    "Phone Code": "+240",
-    "Flag": "🇬🇶",
-    "Currency": "Franc",
-    "Currency Code": "XAF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Spain",
-    "Country Code": "ES",
-    "Phone Code": "+34",
-    "Flag": "🇪🇸",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Benin",
-    "Country Code": "BJ",
-    "Phone Code": "+229",
-    "Flag": "🇧🇯",
-    "Currency": "Franc",
-    "Currency Code": "XOF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Sudan",
-    "Country Code": "SD",
-    "Phone Code": "+249",
-    "Flag": "🇸🇩",
-    "Currency": "Pound",
-    "Currency Code": "SDG",
-    "Currency Symbol": "ج.س"
-  },
-  {
-    "Country Name": "Saint Lucia",
-    "Country Code": "LC",
-    "Phone Code": "+1-758",
-    "Flag": "🇱🇨",
-    "Currency": "Dollar",
-    "Currency Code": "XCD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Guam",
-    "Country Code": "GU",
-    "Phone Code": "+1-671",
-    "Flag": "🇬🇺",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Angola",
-    "Country Code": "AO",
-    "Phone Code": "+244",
-    "Flag": "🇦🇴",
-    "Currency": "Kwanza",
-    "Currency Code": "AOA",
-    "Currency Symbol": "Kz"
-  },
-  {
-    "Country Name": "Yemen",
-    "Country Code": "YE",
-    "Phone Code": "+967",
-    "Flag": "🇾🇪",
-    "Currency": "Rial",
-    "Currency Code": "YER",
-    "Currency Symbol": "﷼"
-  },
-  {
-    "Country Name": "South Georgia",
-    "Country Code": "GS",
-    "Phone Code": null,
-    "Flag": "🇬🇸",
-    "Currency": "British pound",
-    "Currency Code": "GBP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Guadeloupe",
-    "Country Code": "GP",
-    "Phone Code": null,
-    "Flag": "🇬🇵",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Maldives",
-    "Country Code": "MV",
-    "Phone Code": "+960",
-    "Flag": "🇲🇻",
-    "Currency": "Rufiyaa",
-    "Currency Code": "MVR",
-    "Currency Symbol": ".ރ"
-  },
-  {
-    "Country Name": "United States",
-    "Country Code": "US",
-    "Phone Code": "+1",
-    "Flag": "🇺🇸",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Uruguay",
-    "Country Code": "UY",
-    "Phone Code": "+598",
-    "Flag": "🇺🇾",
-    "Currency": "Peso",
-    "Currency Code": "UYU",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Cook Islands",
-    "Country Code": "CK",
-    "Phone Code": "+682",
-    "Flag": "🇨🇰",
-    "Currency": "Dollar",
-    "Currency Code": "CKD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Colombia",
-    "Country Code": "CO",
-    "Phone Code": "+57",
-    "Flag": "🇨🇴",
-    "Currency": "Peso",
-    "Currency Code": "COP",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Ecuador",
-    "Country Code": "EC",
-    "Phone Code": "+593",
-    "Flag": "🇪🇨",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Guinea-Bissau",
-    "Country Code": "GW",
-    "Phone Code": "+245",
-    "Flag": "🇬🇼",
-    "Currency": "Franc",
-    "Currency Code": "XOF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Falkland Islands",
-    "Country Code": "FK",
-    "Phone Code": "+500",
-    "Flag": "🇫🇰",
-    "Currency": "Pound",
-    "Currency Code": "FKP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Philippines",
-    "Country Code": "PH",
-    "Phone Code": "+63",
-    "Flag": "🇵🇭",
-    "Currency": "Peso",
-    "Currency Code": "PHP",
-    "Currency Symbol": "₱"
-  },
-  {
-    "Country Name": "Cayman Islands",
-    "Country Code": "KY",
-    "Phone Code": "+1-345",
-    "Flag": "🇰🇾",
-    "Currency": "Dollar",
-    "Currency Code": "KYD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Hong Kong",
-    "Country Code": "HK",
-    "Phone Code": "+852",
-    "Flag": "🇭🇰",
-    "Currency": "Dollar",
-    "Currency Code": "HKD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "South Sudan",
-    "Country Code": "SS",
-    "Phone Code": "+211",
-    "Flag": "🇸🇸",
-    "Currency": "Pound",
-    "Currency Code": "SSP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Wallis and Futuna",
-    "Country Code": "WF",
-    "Phone Code": "+681",
-    "Flag": "🇼🇫",
-    "Currency": "Franc",
-    "Currency Code": "XPF",
-    "Currency Symbol": "₣"
-  },
-  {
-    "Country Name": "Vatican City",
-    "Country Code": "VA",
-    "Phone Code": null,
-    "Flag": "🇻🇦",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "British Indian Ocean Territory",
-    "Country Code": "IO",
-    "Phone Code": "+246",
-    "Flag": "🇮🇴",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Australia",
-    "Country Code": "AU",
-    "Phone Code": "+61",
-    "Flag": "🇦🇺",
-    "Currency": "Dollar",
-    "Currency Code": "AUD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Portugal",
-    "Country Code": "PT",
-    "Phone Code": "+351",
-    "Flag": "🇵🇹",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Cuba",
-    "Country Code": "CU",
-    "Phone Code": "+53",
-    "Flag": "🇨🇺",
-    "Currency": "Peso",
-    "Currency Code": "CUC",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Mauritania",
-    "Country Code": "MR",
-    "Phone Code": "+222",
-    "Flag": "🇲🇷",
-    "Currency": "Ouguiya",
-    "Currency Code": "MRU",
-    "Currency Symbol": "UM"
-  },
-  {
-    "Country Name": "Cyprus",
-    "Country Code": "CY",
-    "Phone Code": "+357",
-    "Flag": "🇨🇾",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "El Salvador",
-    "Country Code": "SV",
-    "Phone Code": "+503",
-    "Flag": "🇸🇻",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Gabon",
-    "Country Code": "GA",
-    "Phone Code": "+241",
-    "Flag": "🇬🇦",
-    "Currency": "Franc",
-    "Currency Code": "XAF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Czech Republic",
-    "Country Code": "CZ",
-    "Phone Code": "+420",
-    "Flag": null,
-    "Currency": "Koruna",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Cameroon",
-    "Country Code": "CM",
-    "Phone Code": "+237",
-    "Flag": "🇨🇲",
-    "Currency": "Franc",
-    "Currency Code": "XAF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Central African Republic",
-    "Country Code": "CF",
-    "Phone Code": "+236",
-    "Flag": "🇨🇫",
-    "Currency": "Franc",
-    "Currency Code": "XAF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Jordan",
-    "Country Code": "JO",
-    "Phone Code": "+962",
-    "Flag": "🇯🇴",
-    "Currency": "Dinar",
-    "Currency Code": "JOD",
-    "Currency Symbol": "د.ا"
-  },
-  {
-    "Country Name": "Guyana",
-    "Country Code": "GY",
-    "Phone Code": "+592",
-    "Flag": "🇬🇾",
-    "Currency": "Dollar",
-    "Currency Code": "GYD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Cape Verde",
-    "Country Code": "CV",
-    "Phone Code": "+238",
-    "Flag": "🇨🇻",
-    "Currency": "Escudo",
-    "Currency Code": "CVE",
-    "Currency Symbol": "Esc"
-  },
-  {
-    "Country Name": "Tokelau",
-    "Country Code": "TK",
-    "Phone Code": "+690",
-    "Flag": "🇹🇰",
-    "Currency": "Dollar",
-    "Currency Code": "NZD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Åland Islands",
-    "Country Code": "AX",
-    "Phone Code": null,
-    "Flag": "🇦🇽",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Denmark",
-    "Country Code": "DK",
-    "Phone Code": "+45",
-    "Flag": "🇩🇰",
-    "Currency": "Krone",
-    "Currency Code": "DKK",
-    "Currency Symbol": "kr"
-  },
-  {
-    "Country Name": "Japan",
-    "Country Code": "JP",
-    "Phone Code": "+81",
-    "Flag": "🇯🇵",
-    "Currency": "Yen",
-    "Currency Code": "JPY",
-    "Currency Symbol": "¥"
-  },
-  {
-    "Country Name": "Bulgaria",
-    "Country Code": "BG",
-    "Phone Code": "+359",
-    "Flag": "🇧🇬",
-    "Currency": "Lev",
-    "Currency Code": "BGN",
-    "Currency Symbol": "лв"
-  },
-  {
-    "Country Name": "Samoa",
-    "Country Code": "WS",
-    "Phone Code": "+685",
-    "Flag": "🇼🇸",
-    "Currency": "Tala",
-    "Currency Code": "WST",
-    "Currency Symbol": "T"
-  },
-  {
-    "Country Name": "Antarctica",
-    "Country Code": "AQ",
-    "Phone Code": "+672",
-    "Flag": "🇦🇶",
-    "Currency": null,
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Mauritius",
-    "Country Code": "MU",
-    "Phone Code": "+230",
-    "Flag": "🇲🇺",
-    "Currency": "Rupee",
-    "Currency Code": "MUR",
-    "Currency Symbol": "₨"
-  },
-  {
-    "Country Name": "Eritrea",
-    "Country Code": "ER",
-    "Phone Code": "+291",
-    "Flag": "🇪🇷",
-    "Currency": "Nakfa",
-    "Currency Code": "ERN",
-    "Currency Symbol": "Nfk"
-  },
-  {
-    "Country Name": "Monaco",
-    "Country Code": "MC",
-    "Phone Code": "+377",
-    "Flag": "🇲🇨",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Canada",
-    "Country Code": "CA",
-    "Phone Code": "+1",
-    "Flag": "🇨🇦",
-    "Currency": "Dollar",
-    "Currency Code": "CAD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Puerto Rico",
-    "Country Code": "PR",
-    "Phone Code": "+1-787, 1-939",
-    "Flag": "🇵🇷",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "U.S. Virgin Islands",
-    "Country Code": "VI",
-    "Phone Code": "+1-340",
-    "Flag": null,
-    "Currency": "Dollar",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Lebanon",
-    "Country Code": "LB",
-    "Phone Code": "+961",
-    "Flag": "🇱🇧",
-    "Currency": "Pound",
-    "Currency Code": "LBP",
-    "Currency Symbol": "ل.ل"
-  },
-  {
-    "Country Name": "Mexico",
-    "Country Code": "MX",
-    "Phone Code": "+52",
-    "Flag": "🇲🇽",
-    "Currency": "Peso",
-    "Currency Code": "MXN",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Guatemala",
-    "Country Code": "GT",
-    "Phone Code": "+502",
-    "Flag": "🇬🇹",
-    "Currency": "Quetzal",
-    "Currency Code": "GTQ",
-    "Currency Symbol": "Q"
-  },
-  {
-    "Country Name": "Turkey",
-    "Country Code": "TR",
-    "Phone Code": "+90",
-    "Flag": "🇹🇷",
-    "Currency": "Lira",
-    "Currency Code": "TRY",
-    "Currency Symbol": "₺"
-  },
-  {
-    "Country Name": "Saint Barthélemy",
-    "Country Code": "BL",
-    "Phone Code": null,
-    "Flag": "🇧🇱",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Malta",
-    "Country Code": "MT",
-    "Phone Code": "+356",
-    "Flag": "🇲🇹",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Reunion",
-    "Country Code": "RE",
-    "Phone Code": "+262",
-    "Flag": null,
-    "Currency": "Euro",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Nigeria",
-    "Country Code": "NG",
-    "Phone Code": "+234",
-    "Flag": "🇳🇬",
-    "Currency": "Naira",
-    "Currency Code": "NGN",
-    "Currency Symbol": "₦"
-  },
-  {
-    "Country Name": "Gambia",
-    "Country Code": "GM",
-    "Phone Code": "+220",
-    "Flag": "🇬🇲",
-    "Currency": "Dalasi",
-    "Currency Code": "GMD",
-    "Currency Symbol": "D"
-  },
-  {
-    "Country Name": "Haiti",
-    "Country Code": "HT",
-    "Phone Code": "+509",
-    "Flag": "🇭🇹",
-    "Currency": "Gourde",
-    "Currency Code": "HTG",
-    "Currency Symbol": "G"
-  },
-  {
-    "Country Name": "Slovenia",
-    "Country Code": "SI",
-    "Phone Code": "+386",
-    "Flag": "🇸🇮",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Martinique",
-    "Country Code": "MQ",
-    "Phone Code": null,
-    "Flag": "🇲🇶",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Iceland",
-    "Country Code": "IS",
-    "Phone Code": "+354",
-    "Flag": "🇮🇸",
-    "Currency": "Krona",
-    "Currency Code": "ISK",
-    "Currency Symbol": "kr"
-  },
-  {
-    "Country Name": "Belize",
-    "Country Code": "BZ",
-    "Phone Code": "+501",
-    "Flag": "🇧🇿",
-    "Currency": "Dollar",
-    "Currency Code": "BZD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Djibouti",
-    "Country Code": "DJ",
-    "Phone Code": "+253",
-    "Flag": "🇩🇯",
-    "Currency": "Franc",
-    "Currency Code": "DJF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Tunisia",
-    "Country Code": "TN",
-    "Phone Code": "+216",
-    "Flag": "🇹🇳",
-    "Currency": "Dinar",
-    "Currency Code": "TND",
-    "Currency Symbol": "د.ت"
-  },
-  {
-    "Country Name": "Turks and Caicos Islands",
-    "Country Code": "TC",
-    "Phone Code": "+1-649",
-    "Flag": "🇹🇨",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Liechtenstein",
-    "Country Code": "LI",
-    "Phone Code": "+423",
-    "Flag": "🇱🇮",
-    "Currency": "Franc",
-    "Currency Code": "CHF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Burundi",
-    "Country Code": "BI",
-    "Phone Code": "+257",
-    "Flag": "🇧🇮",
-    "Currency": "Franc",
-    "Currency Code": "BIF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Myanmar",
-    "Country Code": "MM",
-    "Phone Code": "+95",
-    "Flag": "🇲🇲",
-    "Currency": "Kyat",
-    "Currency Code": "MMK",
-    "Currency Symbol": "Ks"
-  },
-  {
-    "Country Name": "Sint Maarten",
-    "Country Code": "SX",
-    "Phone Code": "+1-721",
-    "Flag": "🇸🇽",
-    "Currency": "Guilder",
-    "Currency Code": "ANG",
-    "Currency Symbol": "ƒ"
-  },
-  {
-    "Country Name": "Hungary",
-    "Country Code": "HU",
-    "Phone Code": "+36",
-    "Flag": "🇭🇺",
-    "Currency": "Forint",
-    "Currency Code": "HUF",
-    "Currency Symbol": "Ft"
-  },
-  {
-    "Country Name": "Netherlands Antilles",
-    "Country Code": "AN",
-    "Phone Code": "+599",
-    "Flag": null,
-    "Currency": "Guilder",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Netherlands",
-    "Country Code": "NL",
-    "Phone Code": "+31",
-    "Flag": "🇳🇱",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Heard Island and McDonald Islands",
-    "Country Code": "HM",
-    "Phone Code": null,
-    "Flag": "🇭🇲",
-    "Currency": null,
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Nepal",
-    "Country Code": "NP",
-    "Phone Code": "+977",
-    "Flag": "🇳🇵",
-    "Currency": "Rupee",
-    "Currency Code": "NPR",
-    "Currency Symbol": "₨"
-  },
-  {
-    "Country Name": "Thailand",
-    "Country Code": "TH",
-    "Phone Code": "+66",
-    "Flag": "🇹🇭",
-    "Currency": "Baht",
-    "Currency Code": "THB",
-    "Currency Symbol": "฿"
-  },
-  {
-    "Country Name": "Marshall Islands",
-    "Country Code": "MH",
-    "Phone Code": "+692",
-    "Flag": "🇲🇭",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Timor-Leste",
-    "Country Code": "TL",
-    "Phone Code": null,
-    "Flag": "🇹🇱",
-    "Currency": "United States dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Iran",
-    "Country Code": "IR",
-    "Phone Code": "+98",
-    "Flag": "🇮🇷",
-    "Currency": "Rial",
-    "Currency Code": "IRR",
-    "Currency Symbol": "﷼"
-  },
-  {
-    "Country Name": "Bermuda",
-    "Country Code": "BM",
-    "Phone Code": "+1-441",
-    "Flag": "🇧🇲",
-    "Currency": "Dollar",
-    "Currency Code": "BMD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "North Macedonia",
-    "Country Code": "MK",
-    "Phone Code": null,
-    "Flag": "🇲🇰",
-    "Currency": "denar",
-    "Currency Code": "MKD",
-    "Currency Symbol": "den"
-  },
-  {
-    "Country Name": "Isle of Man",
-    "Country Code": "IM",
-    "Phone Code": "+44-1624",
-    "Flag": "🇮🇲",
-    "Currency": "Pound",
-    "Currency Code": "GBP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Palestine",
-    "Country Code": "PS",
-    "Phone Code": "+970",
-    "Flag": "🇵🇸",
-    "Currency": "Shekel",
-    "Currency Code": "EGP",
-    "Currency Symbol": "E£"
-  },
-  {
-    "Country Name": "Russia",
-    "Country Code": "RU",
-    "Phone Code": "+7",
-    "Flag": "🇷🇺",
-    "Currency": "Ruble",
-    "Currency Code": "RUB",
-    "Currency Symbol": "₽"
-  },
-  {
-    "Country Name": "Papua New Guinea",
-    "Country Code": "PG",
-    "Phone Code": "+675",
-    "Flag": "🇵🇬",
-    "Currency": "Kina",
-    "Currency Code": "PGK",
-    "Currency Symbol": "K"
-  },
-  {
-    "Country Name": "Saint Vincent and the Grenadines",
-    "Country Code": "VC",
-    "Phone Code": "+1-784",
-    "Flag": "🇻🇨",
-    "Currency": "Dollar",
-    "Currency Code": "XCD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Panama",
-    "Country Code": "PA",
-    "Phone Code": "+507",
-    "Flag": "🇵🇦",
-    "Currency": "Balboa",
-    "Currency Code": "PAB",
-    "Currency Symbol": "B/."
-  },
-  {
-    "Country Name": "Republic of the Congo",
-    "Country Code": "CG",
-    "Phone Code": "+242",
-    "Flag": "🇨🇬",
-    "Currency": "Franc",
-    "Currency Code": "XAF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "United States Minor Outlying Islands",
-    "Country Code": "UM",
-    "Phone Code": null,
-    "Flag": "🇺🇲",
-    "Currency": "United States dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Tajikistan",
-    "Country Code": "TJ",
-    "Phone Code": "+992",
-    "Flag": "🇹🇯",
-    "Currency": "Somoni",
-    "Currency Code": "TJS",
-    "Currency Symbol": "ЅМ"
-  },
-  {
-    "Country Name": "American Samoa",
-    "Country Code": "AS",
-    "Phone Code": "+1-684",
-    "Flag": "🇦🇸",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Singapore",
-    "Country Code": "SG",
-    "Phone Code": "+65",
-    "Flag": "🇸🇬",
-    "Currency": "Dollar",
-    "Currency Code": "SGD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Saint Pierre and Miquelon",
-    "Country Code": "PM",
-    "Phone Code": "+508",
-    "Flag": "🇵🇲",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Saint Kitts and Nevis",
-    "Country Code": "KN",
-    "Phone Code": "+1-869",
-    "Flag": "🇰🇳",
-    "Currency": "Dollar",
-    "Currency Code": "XCD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Kazakhstan",
-    "Country Code": "KZ",
-    "Phone Code": "+7",
-    "Flag": "🇰🇿",
-    "Currency": "Tenge",
-    "Currency Code": "KZT",
-    "Currency Symbol": "₸"
-  },
-  {
-    "Country Name": "Chile",
-    "Country Code": "CL",
-    "Phone Code": "+56",
-    "Flag": "🇨🇱",
-    "Currency": "Peso",
-    "Currency Code": "CLP",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Syria",
-    "Country Code": "SY",
-    "Phone Code": "+963",
-    "Flag": "🇸🇾",
-    "Currency": "Pound",
-    "Currency Code": "SYP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Belgium",
-    "Country Code": "BE",
-    "Phone Code": "+32",
-    "Flag": "🇧🇪",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Jamaica",
-    "Country Code": "JM",
-    "Phone Code": "+1-876",
-    "Flag": "🇯🇲",
-    "Currency": "Dollar",
-    "Currency Code": "JMD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Nicaragua",
-    "Country Code": "NI",
-    "Phone Code": "+505",
-    "Flag": "🇳🇮",
-    "Currency": "Cordoba",
-    "Currency Code": "NIO",
-    "Currency Symbol": "C$"
-  },
-  {
-    "Country Name": "United Arab Emirates",
-    "Country Code": "AE",
-    "Phone Code": "+971",
-    "Flag": "🇦🇪",
-    "Currency": "Dirham",
-    "Currency Code": "AED",
-    "Currency Symbol": "د.إ"
-  },
-  {
-    "Country Name": "Zambia",
-    "Country Code": "ZM",
-    "Phone Code": "+260",
-    "Flag": "🇿🇲",
-    "Currency": "Kwacha",
-    "Currency Code": "ZMW",
-    "Currency Symbol": "ZK"
-  },
-  {
-    "Country Name": "Kuwait",
-    "Country Code": "KW",
-    "Phone Code": "+965",
-    "Flag": "🇰🇼",
-    "Currency": "Dinar",
-    "Currency Code": "KWD",
-    "Currency Symbol": "د.ك"
-  },
-  {
-    "Country Name": "Micronesia",
-    "Country Code": "FM",
-    "Phone Code": "+691",
-    "Flag": "🇫🇲",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "New Zealand",
-    "Country Code": "NZ",
-    "Phone Code": "+64",
-    "Flag": "🇳🇿",
-    "Currency": "Dollar",
-    "Currency Code": "NZD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "São Tomé and Príncipe",
-    "Country Code": "ST",
-    "Phone Code": null,
-    "Flag": "🇸🇹",
-    "Currency": "São Tomé and Príncipe dobra",
-    "Currency Code": "STN",
-    "Currency Symbol": "Db"
-  },
-  {
-    "Country Name": "Austria",
-    "Country Code": "AT",
-    "Phone Code": "+43",
-    "Flag": "🇦🇹",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Saint Helena",
-    "Country Code": "SH",
-    "Phone Code": "+290",
-    "Flag": null,
-    "Currency": "Pound",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Pitcairn",
-    "Country Code": "PN",
-    "Phone Code": "+64",
-    "Flag": null,
-    "Currency": "Dollar",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Caribbean Netherlands",
-    "Country Code": "BQ",
-    "Phone Code": null,
-    "Flag": "🇧🇶",
-    "Currency": "United States dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Gibraltar",
-    "Country Code": "GI",
-    "Phone Code": "+350",
-    "Flag": "🇬🇮",
-    "Currency": "Pound",
-    "Currency Code": "GIP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Slovakia",
-    "Country Code": "SK",
-    "Phone Code": "+421",
-    "Flag": "🇸🇰",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "East Timor",
-    "Country Code": "TL",
-    "Phone Code": "+670",
-    "Flag": null,
-    "Currency": "Dollar",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Iraq",
-    "Country Code": "IQ",
-    "Phone Code": "+964",
-    "Flag": "🇮🇶",
-    "Currency": "Dinar",
-    "Currency Code": "IQD",
-    "Currency Symbol": "ع.د"
-  },
-  {
-    "Country Name": "Botswana",
-    "Country Code": "BW",
-    "Phone Code": "+267",
-    "Flag": "🇧🇼",
-    "Currency": "Pula",
-    "Currency Code": "BWP",
-    "Currency Symbol": "P"
-  },
-  {
-    "Country Name": "Costa Rica",
-    "Country Code": "CR",
-    "Phone Code": "+506",
-    "Flag": "🇨🇷",
-    "Currency": "Colon",
-    "Currency Code": "CRC",
-    "Currency Symbol": "₡"
-  },
-  {
-    "Country Name": "Vietnam",
-    "Country Code": "VN",
-    "Phone Code": "+84",
-    "Flag": "🇻🇳",
-    "Currency": "Dong",
-    "Currency Code": "VND",
-    "Currency Symbol": "₫"
-  },
-  {
-    "Country Name": "Libya",
-    "Country Code": "LY",
-    "Phone Code": "+218",
-    "Flag": "🇱🇾",
-    "Currency": "Dinar",
-    "Currency Code": "LYD",
-    "Currency Symbol": "ل.د"
-  },
-  {
-    "Country Name": "Bangladesh",
-    "Country Code": "BD",
-    "Phone Code": "+880",
-    "Flag": "🇧🇩",
-    "Currency": "Taka",
-    "Currency Code": "BDT",
-    "Currency Symbol": "৳"
-  },
-  {
-    "Country Name": "French Southern and Antarctic Lands",
-    "Country Code": "TF",
-    "Phone Code": null,
-    "Flag": "🇹🇫",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Sweden",
-    "Country Code": "SE",
-    "Phone Code": "+46",
-    "Flag": "🇸🇪",
-    "Currency": "Krona",
-    "Currency Code": "SEK",
-    "Currency Symbol": "kr"
-  },
-  {
-    "Country Name": "Norfolk Island",
-    "Country Code": "NF",
-    "Phone Code": null,
-    "Flag": "🇳🇫",
-    "Currency": "Australian dollar",
-    "Currency Code": "AUD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Pakistan",
-    "Country Code": "PK",
-    "Phone Code": "+92",
-    "Flag": "🇵🇰",
-    "Currency": "Rupee",
-    "Currency Code": "PKR",
-    "Currency Symbol": "₨"
-  },
-  {
-    "Country Name": "Rwanda",
-    "Country Code": "RW",
-    "Phone Code": "+250",
-    "Flag": "🇷🇼",
-    "Currency": "Franc",
-    "Currency Code": "RWF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Nauru",
-    "Country Code": "NR",
-    "Phone Code": "+674",
-    "Flag": "🇳🇷",
-    "Currency": "Dollar",
-    "Currency Code": "AUD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Burkina Faso",
-    "Country Code": "BF",
-    "Phone Code": "+226",
-    "Flag": "🇧🇫",
-    "Currency": "Franc",
-    "Currency Code": "XOF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Niger",
-    "Country Code": "NE",
-    "Phone Code": "+227",
-    "Flag": "🇳🇪",
-    "Currency": "Franc",
-    "Currency Code": "XOF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "United Kingdom",
-    "Country Code": "GB",
-    "Phone Code": "+44",
-    "Flag": "🇬🇧",
-    "Currency": "Pound",
-    "Currency Code": "GBP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Ivory Coast",
-    "Country Code": "CI",
-    "Phone Code": "+225",
-    "Flag": "🇨🇮",
-    "Currency": "Franc",
-    "Currency Code": "XOF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "DR Congo",
-    "Country Code": "CD",
-    "Phone Code": null,
-    "Flag": "🇨🇩",
-    "Currency": "Congolese franc",
-    "Currency Code": "CDF",
-    "Currency Symbol": "FC"
-  },
-  {
-    "Country Name": "Antigua and Barbuda",
-    "Country Code": "AG",
-    "Phone Code": "+1-268",
-    "Flag": "🇦🇬",
-    "Currency": "Dollar",
-    "Currency Code": "XCD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Somalia",
-    "Country Code": "SO",
-    "Phone Code": "+252",
-    "Flag": "🇸🇴",
-    "Currency": "Shilling",
-    "Currency Code": "SOS",
-    "Currency Symbol": "Sh"
-  },
-  {
-    "Country Name": "Finland",
-    "Country Code": "FI",
-    "Phone Code": "+358",
-    "Flag": "🇫🇮",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Bahamas",
-    "Country Code": "BS",
-    "Phone Code": "+1-242",
-    "Flag": "🇧🇸",
-    "Currency": "Dollar",
-    "Currency Code": "BSD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Lithuania",
-    "Country Code": "LT",
-    "Phone Code": "+370",
-    "Flag": "🇱🇹",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "South Africa",
-    "Country Code": "ZA",
-    "Phone Code": "+27",
-    "Flag": "🇿🇦",
-    "Currency": "Rand",
-    "Currency Code": "ZAR",
-    "Currency Symbol": "R"
-  },
-  {
-    "Country Name": "Svalbard and Jan Mayen",
-    "Country Code": "SJ",
-    "Phone Code": "+47",
-    "Flag": "🇸🇯",
-    "Currency": "Krone",
-    "Currency Code": "NOK",
-    "Currency Symbol": "kr"
-  },
-  {
-    "Country Name": "Western Sahara",
-    "Country Code": "EH",
-    "Phone Code": "+212",
-    "Flag": "🇪🇭",
-    "Currency": "Dirham",
-    "Currency Code": "DZD",
-    "Currency Symbol": "دج"
-  },
-  {
-    "Country Name": "Kyrgyzstan",
-    "Country Code": "KG",
-    "Phone Code": "+996",
-    "Flag": "🇰🇬",
-    "Currency": "Som",
-    "Currency Code": "KGS",
-    "Currency Symbol": "с"
-  },
-  {
-    "Country Name": "Macau",
-    "Country Code": "MO",
-    "Phone Code": "+853",
-    "Flag": "🇲🇴",
-    "Currency": "Pataca",
-    "Currency Code": "MOP",
-    "Currency Symbol": "P"
-  },
-  {
-    "Country Name": "Ghana",
-    "Country Code": "GH",
-    "Phone Code": "+233",
-    "Flag": "🇬🇭",
-    "Currency": "Cedi",
-    "Currency Code": "GHS",
-    "Currency Symbol": "₵"
-  },
-  {
-    "Country Name": "Lesotho",
-    "Country Code": "LS",
-    "Phone Code": "+266",
-    "Flag": "🇱🇸",
-    "Currency": "Loti",
-    "Currency Code": "LSL",
-    "Currency Symbol": "L"
-  },
-  {
-    "Country Name": "Bahrain",
-    "Country Code": "BH",
-    "Phone Code": "+973",
-    "Flag": "🇧🇭",
-    "Currency": "Dinar",
-    "Currency Code": "BHD",
-    "Currency Symbol": ".د.ب"
-  },
-  {
-    "Country Name": "Tanzania",
-    "Country Code": "TZ",
-    "Phone Code": "+255",
-    "Flag": "🇹🇿",
-    "Currency": "Shilling",
-    "Currency Code": "TZS",
-    "Currency Symbol": "Sh"
-  },
-  {
-    "Country Name": "China",
-    "Country Code": "CN",
-    "Phone Code": "+86",
-    "Flag": "🇨🇳",
-    "Currency": "Yuan Renminbi",
-    "Currency Code": "CNY",
-    "Currency Symbol": "¥"
-  },
-  {
-    "Country Name": "Montenegro",
-    "Country Code": "ME",
-    "Phone Code": "+382",
-    "Flag": "🇲🇪",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Laos",
-    "Country Code": "LA",
-    "Phone Code": "+856",
-    "Flag": "🇱🇦",
-    "Currency": "Kip",
-    "Currency Code": "LAK",
-    "Currency Symbol": "₭"
-  },
-  {
-    "Country Name": "Bhutan",
-    "Country Code": "BT",
-    "Phone Code": "+975",
-    "Flag": "🇧🇹",
-    "Currency": "Ngultrum",
-    "Currency Code": "BTN",
-    "Currency Symbol": "Nu."
-  },
-  {
-    "Country Name": "South Korea",
-    "Country Code": "KR",
-    "Phone Code": "+82",
-    "Flag": "🇰🇷",
-    "Currency": "Won",
-    "Currency Code": "KRW",
-    "Currency Symbol": "₩"
-  },
-  {
-    "Country Name": "Kiribati",
-    "Country Code": "KI",
-    "Phone Code": "+686",
-    "Flag": "🇰🇮",
-    "Currency": "Dollar",
-    "Currency Code": "AUD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Senegal",
-    "Country Code": "SN",
-    "Phone Code": "+221",
-    "Flag": "🇸🇳",
-    "Currency": "Franc",
-    "Currency Code": "XOF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Turkmenistan",
-    "Country Code": "TM",
-    "Phone Code": "+993",
-    "Flag": "🇹🇲",
-    "Currency": "Manat",
-    "Currency Code": "TMT",
-    "Currency Symbol": "m"
-  },
-  {
-    "Country Name": "Italy",
-    "Country Code": "IT",
-    "Phone Code": "+39",
-    "Flag": "🇮🇹",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Israel",
-    "Country Code": "IL",
-    "Phone Code": "+972",
-    "Flag": "🇮🇱",
-    "Currency": "Shekel",
-    "Currency Code": "ILS",
-    "Currency Symbol": "₪"
-  },
-  {
-    "Country Name": "New Caledonia",
-    "Country Code": "NC",
-    "Phone Code": "+687",
-    "Flag": "🇳🇨",
-    "Currency": "Franc",
-    "Currency Code": "XPF",
-    "Currency Symbol": "₣"
-  },
-  {
-    "Country Name": "Armenia",
-    "Country Code": "AM",
-    "Phone Code": "+374",
-    "Flag": "🇦🇲",
-    "Currency": "Dram",
-    "Currency Code": "AMD",
-    "Currency Symbol": "֏"
-  },
-  {
-    "Country Name": "Curacao",
-    "Country Code": "CW",
-    "Phone Code": "+599",
-    "Flag": null,
-    "Currency": "Guilder",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Eswatini",
-    "Country Code": "SZ",
-    "Phone Code": null,
-    "Flag": "🇸🇿",
-    "Currency": "Swazi lilangeni",
-    "Currency Code": "SZL",
-    "Currency Symbol": "L"
-  },
-  {
-    "Country Name": "United States Virgin Islands",
-    "Country Code": "VI",
-    "Phone Code": null,
-    "Flag": "🇻🇮",
-    "Currency": "United States dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Paraguay",
-    "Country Code": "PY",
-    "Phone Code": "+595",
-    "Flag": "🇵🇾",
-    "Currency": "Guarani",
-    "Currency Code": "PYG",
-    "Currency Symbol": "₲"
-  },
-  {
-    "Country Name": "Uzbekistan",
-    "Country Code": "UZ",
-    "Phone Code": "+998",
-    "Flag": "🇺🇿",
-    "Currency": "Som",
-    "Currency Code": "UZS",
-    "Currency Symbol": "so'm"
-  },
-  {
-    "Country Name": "Anguilla",
-    "Country Code": "AI",
-    "Phone Code": "+1-264",
-    "Flag": "🇦🇮",
-    "Currency": "Dollar",
-    "Currency Code": "XCD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Saint Barthelemy",
-    "Country Code": "BL",
-    "Phone Code": "+590",
-    "Flag": null,
-    "Currency": "Euro",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Palau",
-    "Country Code": "PW",
-    "Phone Code": "+680",
-    "Flag": "🇵🇼",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Namibia",
-    "Country Code": "NA",
-    "Phone Code": "+264",
-    "Flag": "🇳🇦",
-    "Currency": "Dollar",
-    "Currency Code": "NAD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Mayotte",
-    "Country Code": "YT",
-    "Phone Code": "+262",
-    "Flag": "🇾🇹",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Venezuela",
-    "Country Code": "VE",
-    "Phone Code": "+58",
-    "Flag": "🇻🇪",
-    "Currency": "Bolivar",
-    "Currency Code": "VES",
-    "Currency Symbol": "Bs.S."
-  },
-  {
-    "Country Name": "Morocco",
-    "Country Code": "MA",
-    "Phone Code": "+212",
-    "Flag": "🇲🇦",
-    "Currency": "Dirham",
-    "Currency Code": "MAD",
-    "Currency Symbol": "د.م."
-  },
-  {
-    "Country Name": "Saint Helena, Ascension and Tristan da Cunha",
-    "Country Code": "SH",
-    "Phone Code": null,
-    "Flag": "🇸🇭",
-    "Currency": "Pound sterling",
-    "Currency Code": "GBP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Democratic Republic of the Congo",
-    "Country Code": "CD",
-    "Phone Code": "+243",
-    "Flag": null,
-    "Currency": "Franc",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Greece",
-    "Country Code": "GR",
-    "Phone Code": "+30",
-    "Flag": "🇬🇷",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Greenland",
-    "Country Code": "GL",
-    "Phone Code": "+299",
-    "Flag": "🇬🇱",
-    "Currency": "Krone",
-    "Currency Code": "DKK",
-    "Currency Symbol": "kr."
-  },
-  {
-    "Country Name": "Moldova",
-    "Country Code": "MD",
-    "Phone Code": "+373",
-    "Flag": "🇲🇩",
-    "Currency": "Leu",
-    "Currency Code": "MDL",
-    "Currency Symbol": "L"
-  },
-  {
-    "Country Name": "Bosnia and Herzegovina",
-    "Country Code": "BA",
-    "Phone Code": "+387",
-    "Flag": "🇧🇦",
-    "Currency": "Marka",
-    "Currency Code": "BAM",
-    "Currency Symbol": "KM"
-  },
-  {
-    "Country Name": "Albania",
-    "Country Code": "AL",
-    "Phone Code": "+355",
-    "Flag": "🇦🇱",
-    "Currency": "Lek",
-    "Currency Code": "ALL",
-    "Currency Symbol": "L"
-  },
-  {
-    "Country Name": "Sri Lanka",
-    "Country Code": "LK",
-    "Phone Code": "+94",
-    "Flag": "🇱🇰",
-    "Currency": "Rupee",
-    "Currency Code": "LKR",
-    "Currency Symbol": "Rs  රු"
-  },
-  {
-    "Country Name": "Romania",
-    "Country Code": "RO",
-    "Phone Code": "+40",
-    "Flag": "🇷🇴",
-    "Currency": "Leu",
-    "Currency Code": "RON",
-    "Currency Symbol": "lei"
-  },
-  {
-    "Country Name": "Cambodia",
-    "Country Code": "KH",
-    "Phone Code": "+855",
-    "Flag": "🇰🇭",
-    "Currency": "Riels",
-    "Currency Code": "KHR",
-    "Currency Symbol": "៛"
-  },
-  {
-    "Country Name": "Malaysia",
-    "Country Code": "MY",
-    "Phone Code": "+60",
-    "Flag": "🇲🇾",
-    "Currency": "Ringgit",
-    "Currency Code": "MYR",
-    "Currency Symbol": "RM"
-  },
-  {
-    "Country Name": "Mozambique",
-    "Country Code": "MZ",
-    "Phone Code": "+258",
-    "Flag": "🇲🇿",
-    "Currency": "Metical",
-    "Currency Code": "MZN",
-    "Currency Symbol": "MT"
-  },
-  {
-    "Country Name": "Tonga",
-    "Country Code": "TO",
-    "Phone Code": "+676",
-    "Flag": "🇹🇴",
-    "Currency": "Pa'anga",
-    "Currency Code": "TOP",
-    "Currency Symbol": "T$"
-  },
-  {
-    "Country Name": "India",
-    "Country Code": "IN",
-    "Phone Code": "+91",
-    "Flag": "🇮🇳",
-    "Currency": "Rupee",
-    "Currency Code": "INR",
-    "Currency Symbol": "₹"
-  },
-  {
-    "Country Name": "Azerbaijan",
-    "Country Code": "AZ",
-    "Phone Code": "+994",
-    "Flag": "🇦🇿",
-    "Currency": "Manat",
-    "Currency Code": "AZN",
-    "Currency Symbol": "₼"
-  },
-  {
-    "Country Name": "Vatican",
-    "Country Code": "VA",
-    "Phone Code": "+379",
-    "Flag": null,
-    "Currency": "Euro",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "British Virgin Islands",
-    "Country Code": "VG",
-    "Phone Code": "+1-284",
-    "Flag": "🇻🇬",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Niue",
-    "Country Code": "NU",
-    "Phone Code": "+683",
-    "Flag": "🇳🇺",
-    "Currency": "Dollar",
-    "Currency Code": "NZD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Bouvet Island",
-    "Country Code": "BV",
-    "Phone Code": null,
-    "Flag": "🇧🇻",
-    "Currency": null,
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Christmas Island",
-    "Country Code": "CX",
-    "Phone Code": "+61",
-    "Flag": "🇨🇽",
-    "Currency": "Dollar",
-    "Currency Code": "AUD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Switzerland",
-    "Country Code": "CH",
-    "Phone Code": "+41",
-    "Flag": "🇨🇭",
-    "Currency": "Franc",
-    "Currency Code": "CHF",
-    "Currency Symbol": "Fr."
-  },
-  {
-    "Country Name": "Cocos (Keeling) Islands",
-    "Country Code": "CC",
-    "Phone Code": null,
-    "Flag": "🇨🇨",
-    "Currency": "Australian dollar",
-    "Currency Code": "AUD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "North Korea",
-    "Country Code": "KP",
-    "Phone Code": "+850",
-    "Flag": "🇰🇵",
-    "Currency": "Won",
-    "Currency Code": "KPW",
-    "Currency Symbol": "₩"
-  },
-  {
-    "Country Name": "Poland",
-    "Country Code": "PL",
-    "Phone Code": "+48",
-    "Flag": "🇵🇱",
-    "Currency": "Zloty",
-    "Currency Code": "PLN",
-    "Currency Symbol": "zł"
-  },
-  {
-    "Country Name": "French Guiana",
-    "Country Code": "GF",
-    "Phone Code": null,
-    "Flag": "🇬🇫",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Solomon Islands",
-    "Country Code": "SB",
-    "Phone Code": "+677",
-    "Flag": "🇸🇧",
-    "Currency": "Dollar",
-    "Currency Code": "SBD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Belarus",
-    "Country Code": "BY",
-    "Phone Code": "+375",
-    "Flag": "🇧🇾",
-    "Currency": "Ruble",
-    "Currency Code": "BYN",
-    "Currency Symbol": "Br"
-  },
-  {
-    "Country Name": "Algeria",
-    "Country Code": "DZ",
-    "Phone Code": "+213",
-    "Flag": "🇩🇿",
-    "Currency": "Dinar",
-    "Currency Code": "DZD",
-    "Currency Symbol": "د.ج"
-  },
-  {
-    "Country Name": "Mongolia",
-    "Country Code": "MN",
-    "Phone Code": "+976",
-    "Flag": "🇲🇳",
-    "Currency": "Tugrik",
-    "Currency Code": "MNT",
-    "Currency Symbol": "₮"
-  },
-  {
-    "Country Name": "Honduras",
-    "Country Code": "HN",
-    "Phone Code": "+504",
-    "Flag": "🇭🇳",
-    "Currency": "Lempira",
-    "Currency Code": "HNL",
-    "Currency Symbol": "L"
-  },
-  {
-    "Country Name": "Sao Tome and Principe",
-    "Country Code": "ST",
-    "Phone Code": "+239",
-    "Flag": null,
-    "Currency": "Dobra",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Luxembourg",
-    "Country Code": "LU",
-    "Phone Code": "+352",
-    "Flag": "🇱🇺",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Guinea",
-    "Country Code": "GN",
-    "Phone Code": "+224",
-    "Flag": "🇬🇳",
-    "Currency": "Franc",
-    "Currency Code": "GNF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Sierra Leone",
-    "Country Code": "SL",
-    "Phone Code": "+232",
-    "Flag": "🇸🇱",
-    "Currency": "Leone",
-    "Currency Code": "SLE",
-    "Currency Symbol": "Le"
-  },
-  {
-    "Country Name": "Taiwan",
-    "Country Code": "TW",
-    "Phone Code": "+886",
-    "Flag": "🇹🇼",
-    "Currency": "Dollar",
-    "Currency Code": "TWD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Mali",
-    "Country Code": "ML",
-    "Phone Code": "+223",
-    "Flag": "🇲🇱",
-    "Currency": "Franc",
-    "Currency Code": "XOF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Saudi Arabia",
-    "Country Code": "SA",
-    "Phone Code": "+966",
-    "Flag": "🇸🇦",
-    "Currency": "Rial",
-    "Currency Code": "SAR",
-    "Currency Symbol": "ر.س"
-  },
-  {
-    "Country Name": "Swaziland",
-    "Country Code": "SZ",
-    "Phone Code": "+268",
-    "Flag": null,
-    "Currency": "Lilangeni",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Norway",
-    "Country Code": "NO",
-    "Phone Code": "+47",
-    "Flag": "🇳🇴",
-    "Currency": "Krone",
-    "Currency Code": "NOK",
-    "Currency Symbol": "kr"
-  },
-  {
-    "Country Name": "Réunion",
-    "Country Code": "RE",
-    "Phone Code": null,
-    "Flag": "🇷🇪",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Germany",
-    "Country Code": "DE",
-    "Phone Code": "+49",
-    "Flag": "🇩🇪",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Uganda",
-    "Country Code": "UG",
-    "Phone Code": "+256",
-    "Flag": "🇺🇬",
-    "Currency": "Shilling",
-    "Currency Code": "UGX",
-    "Currency Symbol": "Sh"
-  },
-  {
-    "Country Name": "Liberia",
-    "Country Code": "LR",
-    "Phone Code": "+231",
-    "Flag": "🇱🇷",
-    "Currency": "Dollar",
-    "Currency Code": "LRD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Ukraine",
-    "Country Code": "UA",
-    "Phone Code": "+380",
-    "Flag": "🇺🇦",
-    "Currency": "Hryvnia",
-    "Currency Code": "UAH",
-    "Currency Symbol": "₴"
-  },
-  {
-    "Country Name": "Latvia",
-    "Country Code": "LV",
-    "Phone Code": "+371",
-    "Flag": "🇱🇻",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Montserrat",
-    "Country Code": "MS",
-    "Phone Code": "+1-664",
-    "Flag": "🇲🇸",
-    "Currency": "Dollar",
-    "Currency Code": "XCD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Qatar",
-    "Country Code": "QA",
-    "Phone Code": "+974",
-    "Flag": "🇶🇦",
-    "Currency": "Rial",
-    "Currency Code": "QAR",
-    "Currency Symbol": "ر.ق"
-  },
-  {
-    "Country Name": "Oman",
-    "Country Code": "OM",
-    "Phone Code": "+968",
-    "Flag": "🇴🇲",
-    "Currency": "Rial",
-    "Currency Code": "OMR",
-    "Currency Symbol": "ر.ع."
-  },
-  {
-    "Country Name": "Estonia",
-    "Country Code": "EE",
-    "Phone Code": "+372",
-    "Flag": "🇪🇪",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Comoros",
-    "Country Code": "KM",
-    "Phone Code": "+269",
-    "Flag": "🇰🇲",
-    "Currency": "Franc",
-    "Currency Code": "KMF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Peru",
-    "Country Code": "PE",
-    "Phone Code": "+51",
-    "Flag": "🇵🇪",
-    "Currency": "Sol",
-    "Currency Code": "PEN",
-    "Currency Symbol": "S/ "
-  },
-  {
-    "Country Name": "Chad",
-    "Country Code": "TD",
-    "Phone Code": "+235",
-    "Flag": "🇹🇩",
-    "Currency": "Franc",
-    "Currency Code": "XAF",
-    "Currency Symbol": "Fr"
-  },
-  {
-    "Country Name": "Jersey",
-    "Country Code": "JE",
-    "Phone Code": "+44-1534",
-    "Flag": "🇯🇪",
-    "Currency": "Pound",
-    "Currency Code": "GBP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Cocos Islands",
-    "Country Code": "CC",
-    "Phone Code": "+61",
-    "Flag": null,
-    "Currency": "Dollar",
-    "Currency Code": null,
-    "Currency Symbol": null
-  },
-  {
-    "Country Name": "Dominica",
-    "Country Code": "DM",
-    "Phone Code": "+1-767",
-    "Flag": "🇩🇲",
-    "Currency": "Dollar",
-    "Currency Code": "XCD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Northern Mariana Islands",
-    "Country Code": "MP",
-    "Phone Code": "+1-670",
-    "Flag": "🇲🇵",
-    "Currency": "Dollar",
-    "Currency Code": "USD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Kosovo",
-    "Country Code": "XK",
-    "Phone Code": "+383",
-    "Flag": "🇽🇰",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Egypt",
-    "Country Code": "EG",
-    "Phone Code": "+20",
-    "Flag": "🇪🇬",
-    "Currency": "Pound",
-    "Currency Code": "EGP",
-    "Currency Symbol": "£"
-  },
-  {
-    "Country Name": "Curaçao",
-    "Country Code": "CW",
-    "Phone Code": null,
-    "Flag": "🇨🇼",
-    "Currency": "Netherlands Antillean guilder",
-    "Currency Code": "ANG",
-    "Currency Symbol": "ƒ"
-  },
-  {
-    "Country Name": "French Polynesia",
-    "Country Code": "PF",
-    "Phone Code": "+689",
-    "Flag": "🇵🇫",
-    "Currency": "Franc",
-    "Currency Code": "XPF",
-    "Currency Symbol": "₣"
-  },
-  {
-    "Country Name": "Bolivia",
-    "Country Code": "BO",
-    "Phone Code": "+591",
-    "Flag": "🇧🇴",
-    "Currency": "Boliviano",
-    "Currency Code": "BOB",
-    "Currency Symbol": "Bs."
-  },
-  {
-    "Country Name": "Croatia",
-    "Country Code": "HR",
-    "Phone Code": "+385",
-    "Flag": "🇭🇷",
-    "Currency": "Kuna",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Ireland",
-    "Country Code": "IE",
-    "Phone Code": "+353",
-    "Flag": "🇮🇪",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Faroe Islands",
-    "Country Code": "FO",
-    "Phone Code": "+298",
-    "Flag": "🇫🇴",
-    "Currency": "Krone",
-    "Currency Code": "DKK",
-    "Currency Symbol": "kr"
-  },
-  {
-    "Country Name": "Serbia",
-    "Country Code": "RS",
-    "Phone Code": "+381",
-    "Flag": "🇷🇸",
-    "Currency": "Dinar",
-    "Currency Code": "RSD",
-    "Currency Symbol": "дин."
-  },
-  {
-    "Country Name": "Andorra",
-    "Country Code": "AD",
-    "Phone Code": "+376",
-    "Flag": "🇦🇩",
-    "Currency": "Euro",
-    "Currency Code": "EUR",
-    "Currency Symbol": "€"
-  },
-  {
-    "Country Name": "Malawi",
-    "Country Code": "MW",
-    "Phone Code": "+265",
-    "Flag": "🇲🇼",
-    "Currency": "Kwacha",
-    "Currency Code": "MWK",
-    "Currency Symbol": "MK"
-  },
-  {
-    "Country Name": "Seychelles",
-    "Country Code": "SC",
-    "Phone Code": "+248",
-    "Flag": "🇸🇨",
-    "Currency": "Rupee",
-    "Currency Code": "SCR",
-    "Currency Symbol": "₨"
-  },
-  {
-    "Country Name": "Czechia",
-    "Country Code": "CZ",
-    "Phone Code": null,
-    "Flag": "🇨🇿",
-    "Currency": "Czech koruna",
-    "Currency Code": "CZK",
-    "Currency Symbol": "Kč"
-  },
-  {
-    "Country Name": "Fiji",
-    "Country Code": "FJ",
-    "Phone Code": "+679",
-    "Flag": "🇫🇯",
-    "Currency": "Dollar",
-    "Currency Code": "FJD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Suriname",
-    "Country Code": "SR",
-    "Phone Code": "+597",
-    "Flag": "🇸🇷",
-    "Currency": "Dollar",
-    "Currency Code": "SRD",
-    "Currency Symbol": "$"
-  },
-  {
-    "Country Name": "Georgia",
-    "Country Code": "GE",
-    "Phone Code": "+995",
-    "Flag": "🇬🇪",
-    "Currency": "Lari",
-    "Currency Code": "GEL",
-    "Currency Symbol": "₾"
+    "country_name": "Aruba",
+    "country_code": "AW",
+    "phone_code": "+297",
+    "flag": "🇦🇼",
+    "currency": "Guilder",
+    "currency_code": "AWG",
+    "currency_symbol": "ƒ"
+  },
+  {
+    "country_name": "Brunei",
+    "country_code": "BN",
+    "phone_code": "+673",
+    "flag": "🇧🇳",
+    "currency": "Dollar",
+    "currency_code": "BND",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Indonesia",
+    "country_code": "ID",
+    "phone_code": "+62",
+    "flag": "🇮🇩",
+    "currency": "Rupiah",
+    "currency_code": "IDR",
+    "currency_symbol": "Rp"
+  },
+  {
+    "country_name": "San Marino",
+    "country_code": "SM",
+    "phone_code": "+378",
+    "flag": "🇸🇲",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Zimbabwe",
+    "country_code": "ZW",
+    "phone_code": "+263",
+    "flag": "🇿🇼",
+    "currency": "Dollar",
+    "currency_code": "ZWL",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Trinidad and Tobago",
+    "country_code": "TT",
+    "phone_code": "+1-868",
+    "flag": "🇹🇹",
+    "currency": "Dollar",
+    "currency_code": "TTD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Pitcairn Islands",
+    "country_code": "PN",
+    "phone_code": null,
+    "flag": "🇵🇳",
+    "currency": "New Zealand dollar",
+    "currency_code": "NZD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Argentina",
+    "country_code": "AR",
+    "phone_code": "+54",
+    "flag": "🇦🇷",
+    "currency": "Peso",
+    "currency_code": "ARS",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Togo",
+    "country_code": "TG",
+    "phone_code": "+228",
+    "flag": "🇹🇬",
+    "currency": "Franc",
+    "currency_code": "XOF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Brazil",
+    "country_code": "BR",
+    "phone_code": "+55",
+    "flag": "🇧🇷",
+    "currency": "Real",
+    "currency_code": "BRL",
+    "currency_symbol": "R$"
+  },
+  {
+    "country_name": "Ethiopia",
+    "country_code": "ET",
+    "phone_code": "+251",
+    "flag": "🇪🇹",
+    "currency": "Birr",
+    "currency_code": "ETB",
+    "currency_symbol": "Br"
+  },
+  {
+    "country_name": "Grenada",
+    "country_code": "GD",
+    "phone_code": "+1-473",
+    "flag": "🇬🇩",
+    "currency": "Dollar",
+    "currency_code": "XCD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Saint Martin",
+    "country_code": "MF",
+    "phone_code": "+590",
+    "flag": "🇲🇫",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "France",
+    "country_code": "FR",
+    "phone_code": "+33",
+    "flag": "🇫🇷",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Tuvalu",
+    "country_code": "TV",
+    "phone_code": "+688",
+    "flag": "🇹🇻",
+    "currency": "Dollar",
+    "currency_code": "AUD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Barbados",
+    "country_code": "BB",
+    "phone_code": "+1-246",
+    "flag": "🇧🇧",
+    "currency": "Dollar",
+    "currency_code": "BBD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Dominican Republic",
+    "country_code": "DO",
+    "phone_code": "+1-809, 1-829, 1-849",
+    "flag": "🇩🇴",
+    "currency": "Peso",
+    "currency_code": "DOP",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Macedonia",
+    "country_code": "MK",
+    "phone_code": "+389",
+    "flag": null,
+    "currency": "Denar",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Guernsey",
+    "country_code": "GG",
+    "phone_code": "+44-1481",
+    "flag": "🇬🇬",
+    "currency": "Pound",
+    "currency_code": "GBP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Madagascar",
+    "country_code": "MG",
+    "phone_code": "+261",
+    "flag": "🇲🇬",
+    "currency": "Ariary",
+    "currency_code": "MGA",
+    "currency_symbol": "Ar"
+  },
+  {
+    "country_name": "Vanuatu",
+    "country_code": "VU",
+    "phone_code": "+678",
+    "flag": "🇻🇺",
+    "currency": "Vatu",
+    "currency_code": "VUV",
+    "currency_symbol": "Vt"
+  },
+  {
+    "country_name": "Kenya",
+    "country_code": "KE",
+    "phone_code": "+254",
+    "flag": "🇰🇪",
+    "currency": "Shilling",
+    "currency_code": "KES",
+    "currency_symbol": "Sh"
+  },
+  {
+    "country_name": "Afghanistan",
+    "country_code": "AF",
+    "phone_code": "+93",
+    "flag": "🇦🇫",
+    "currency": "Afghani",
+    "currency_code": "AFN",
+    "currency_symbol": "؋"
+  },
+  {
+    "country_name": "Equatorial Guinea",
+    "country_code": "GQ",
+    "phone_code": "+240",
+    "flag": "🇬🇶",
+    "currency": "Franc",
+    "currency_code": "XAF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Spain",
+    "country_code": "ES",
+    "phone_code": "+34",
+    "flag": "🇪🇸",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Benin",
+    "country_code": "BJ",
+    "phone_code": "+229",
+    "flag": "🇧🇯",
+    "currency": "Franc",
+    "currency_code": "XOF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Sudan",
+    "country_code": "SD",
+    "phone_code": "+249",
+    "flag": "🇸🇩",
+    "currency": "Pound",
+    "currency_code": "SDG",
+    "currency_symbol": "ج.س"
+  },
+  {
+    "country_name": "Saint Lucia",
+    "country_code": "LC",
+    "phone_code": "+1-758",
+    "flag": "🇱🇨",
+    "currency": "Dollar",
+    "currency_code": "XCD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Guam",
+    "country_code": "GU",
+    "phone_code": "+1-671",
+    "flag": "🇬🇺",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Angola",
+    "country_code": "AO",
+    "phone_code": "+244",
+    "flag": "🇦🇴",
+    "currency": "Kwanza",
+    "currency_code": "AOA",
+    "currency_symbol": "Kz"
+  },
+  {
+    "country_name": "Yemen",
+    "country_code": "YE",
+    "phone_code": "+967",
+    "flag": "🇾🇪",
+    "currency": "Rial",
+    "currency_code": "YER",
+    "currency_symbol": "﷼"
+  },
+  {
+    "country_name": "South Georgia",
+    "country_code": "GS",
+    "phone_code": null,
+    "flag": "🇬🇸",
+    "currency": "British pound",
+    "currency_code": "GBP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Guadeloupe",
+    "country_code": "GP",
+    "phone_code": null,
+    "flag": "🇬🇵",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Maldives",
+    "country_code": "MV",
+    "phone_code": "+960",
+    "flag": "🇲🇻",
+    "currency": "Rufiyaa",
+    "currency_code": "MVR",
+    "currency_symbol": ".ރ"
+  },
+  {
+    "country_name": "United States",
+    "country_code": "US",
+    "phone_code": "+1",
+    "flag": "🇺🇸",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Uruguay",
+    "country_code": "UY",
+    "phone_code": "+598",
+    "flag": "🇺🇾",
+    "currency": "Peso",
+    "currency_code": "UYU",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Cook Islands",
+    "country_code": "CK",
+    "phone_code": "+682",
+    "flag": "🇨🇰",
+    "currency": "Dollar",
+    "currency_code": "CKD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Colombia",
+    "country_code": "CO",
+    "phone_code": "+57",
+    "flag": "🇨🇴",
+    "currency": "Peso",
+    "currency_code": "COP",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Ecuador",
+    "country_code": "EC",
+    "phone_code": "+593",
+    "flag": "🇪🇨",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Guinea-Bissau",
+    "country_code": "GW",
+    "phone_code": "+245",
+    "flag": "🇬🇼",
+    "currency": "Franc",
+    "currency_code": "XOF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Falkland Islands",
+    "country_code": "FK",
+    "phone_code": "+500",
+    "flag": "🇫🇰",
+    "currency": "Pound",
+    "currency_code": "FKP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Philippines",
+    "country_code": "PH",
+    "phone_code": "+63",
+    "flag": "🇵🇭",
+    "currency": "Peso",
+    "currency_code": "PHP",
+    "currency_symbol": "₱"
+  },
+  {
+    "country_name": "Cayman Islands",
+    "country_code": "KY",
+    "phone_code": "+1-345",
+    "flag": "🇰🇾",
+    "currency": "Dollar",
+    "currency_code": "KYD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Hong Kong",
+    "country_code": "HK",
+    "phone_code": "+852",
+    "flag": "🇭🇰",
+    "currency": "Dollar",
+    "currency_code": "HKD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "South Sudan",
+    "country_code": "SS",
+    "phone_code": "+211",
+    "flag": "🇸🇸",
+    "currency": "Pound",
+    "currency_code": "SSP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Wallis and Futuna",
+    "country_code": "WF",
+    "phone_code": "+681",
+    "flag": "🇼🇫",
+    "currency": "Franc",
+    "currency_code": "XPF",
+    "currency_symbol": "₣"
+  },
+  {
+    "country_name": "Vatican City",
+    "country_code": "VA",
+    "phone_code": null,
+    "flag": "🇻🇦",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "British Indian Ocean Territory",
+    "country_code": "IO",
+    "phone_code": "+246",
+    "flag": "🇮🇴",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Australia",
+    "country_code": "AU",
+    "phone_code": "+61",
+    "flag": "🇦🇺",
+    "currency": "Dollar",
+    "currency_code": "AUD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Portugal",
+    "country_code": "PT",
+    "phone_code": "+351",
+    "flag": "🇵🇹",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Cuba",
+    "country_code": "CU",
+    "phone_code": "+53",
+    "flag": "🇨🇺",
+    "currency": "Peso",
+    "currency_code": "CUC",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Mauritania",
+    "country_code": "MR",
+    "phone_code": "+222",
+    "flag": "🇲🇷",
+    "currency": "Ouguiya",
+    "currency_code": "MRU",
+    "currency_symbol": "UM"
+  },
+  {
+    "country_name": "Cyprus",
+    "country_code": "CY",
+    "phone_code": "+357",
+    "flag": "🇨🇾",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "El Salvador",
+    "country_code": "SV",
+    "phone_code": "+503",
+    "flag": "🇸🇻",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Gabon",
+    "country_code": "GA",
+    "phone_code": "+241",
+    "flag": "🇬🇦",
+    "currency": "Franc",
+    "currency_code": "XAF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Czech Republic",
+    "country_code": "CZ",
+    "phone_code": "+420",
+    "flag": null,
+    "currency": "Koruna",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Cameroon",
+    "country_code": "CM",
+    "phone_code": "+237",
+    "flag": "🇨🇲",
+    "currency": "Franc",
+    "currency_code": "XAF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Central African Republic",
+    "country_code": "CF",
+    "phone_code": "+236",
+    "flag": "🇨🇫",
+    "currency": "Franc",
+    "currency_code": "XAF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Jordan",
+    "country_code": "JO",
+    "phone_code": "+962",
+    "flag": "🇯🇴",
+    "currency": "Dinar",
+    "currency_code": "JOD",
+    "currency_symbol": "د.ا"
+  },
+  {
+    "country_name": "Guyana",
+    "country_code": "GY",
+    "phone_code": "+592",
+    "flag": "🇬🇾",
+    "currency": "Dollar",
+    "currency_code": "GYD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Cape Verde",
+    "country_code": "CV",
+    "phone_code": "+238",
+    "flag": "🇨🇻",
+    "currency": "Escudo",
+    "currency_code": "CVE",
+    "currency_symbol": "Esc"
+  },
+  {
+    "country_name": "Tokelau",
+    "country_code": "TK",
+    "phone_code": "+690",
+    "flag": "🇹🇰",
+    "currency": "Dollar",
+    "currency_code": "NZD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Åland Islands",
+    "country_code": "AX",
+    "phone_code": null,
+    "flag": "🇦🇽",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Denmark",
+    "country_code": "DK",
+    "phone_code": "+45",
+    "flag": "🇩🇰",
+    "currency": "Krone",
+    "currency_code": "DKK",
+    "currency_symbol": "kr"
+  },
+  {
+    "country_name": "Japan",
+    "country_code": "JP",
+    "phone_code": "+81",
+    "flag": "🇯🇵",
+    "currency": "Yen",
+    "currency_code": "JPY",
+    "currency_symbol": "¥"
+  },
+  {
+    "country_name": "Bulgaria",
+    "country_code": "BG",
+    "phone_code": "+359",
+    "flag": "🇧🇬",
+    "currency": "Lev",
+    "currency_code": "BGN",
+    "currency_symbol": "лв"
+  },
+  {
+    "country_name": "Samoa",
+    "country_code": "WS",
+    "phone_code": "+685",
+    "flag": "🇼🇸",
+    "currency": "Tala",
+    "currency_code": "WST",
+    "currency_symbol": "T"
+  },
+  {
+    "country_name": "Antarctica",
+    "country_code": "AQ",
+    "phone_code": "+672",
+    "flag": "🇦🇶",
+    "currency": null,
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Mauritius",
+    "country_code": "MU",
+    "phone_code": "+230",
+    "flag": "🇲🇺",
+    "currency": "Rupee",
+    "currency_code": "MUR",
+    "currency_symbol": "₨"
+  },
+  {
+    "country_name": "Eritrea",
+    "country_code": "ER",
+    "phone_code": "+291",
+    "flag": "🇪🇷",
+    "currency": "Nakfa",
+    "currency_code": "ERN",
+    "currency_symbol": "Nfk"
+  },
+  {
+    "country_name": "Monaco",
+    "country_code": "MC",
+    "phone_code": "+377",
+    "flag": "🇲🇨",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Canada",
+    "country_code": "CA",
+    "phone_code": "+1",
+    "flag": "🇨🇦",
+    "currency": "Dollar",
+    "currency_code": "CAD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Puerto Rico",
+    "country_code": "PR",
+    "phone_code": "+1-787, 1-939",
+    "flag": "🇵🇷",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "U.S. Virgin Islands",
+    "country_code": "VI",
+    "phone_code": "+1-340",
+    "flag": null,
+    "currency": "Dollar",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Lebanon",
+    "country_code": "LB",
+    "phone_code": "+961",
+    "flag": "🇱🇧",
+    "currency": "Pound",
+    "currency_code": "LBP",
+    "currency_symbol": "ل.ل"
+  },
+  {
+    "country_name": "Mexico",
+    "country_code": "MX",
+    "phone_code": "+52",
+    "flag": "🇲🇽",
+    "currency": "Peso",
+    "currency_code": "MXN",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Guatemala",
+    "country_code": "GT",
+    "phone_code": "+502",
+    "flag": "🇬🇹",
+    "currency": "Quetzal",
+    "currency_code": "GTQ",
+    "currency_symbol": "Q"
+  },
+  {
+    "country_name": "Turkey",
+    "country_code": "TR",
+    "phone_code": "+90",
+    "flag": "🇹🇷",
+    "currency": "Lira",
+    "currency_code": "TRY",
+    "currency_symbol": "₺"
+  },
+  {
+    "country_name": "Saint Barthélemy",
+    "country_code": "BL",
+    "phone_code": null,
+    "flag": "🇧🇱",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Malta",
+    "country_code": "MT",
+    "phone_code": "+356",
+    "flag": "🇲🇹",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Reunion",
+    "country_code": "RE",
+    "phone_code": "+262",
+    "flag": null,
+    "currency": "Euro",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Nigeria",
+    "country_code": "NG",
+    "phone_code": "+234",
+    "flag": "🇳🇬",
+    "currency": "Naira",
+    "currency_code": "NGN",
+    "currency_symbol": "₦"
+  },
+  {
+    "country_name": "Gambia",
+    "country_code": "GM",
+    "phone_code": "+220",
+    "flag": "🇬🇲",
+    "currency": "Dalasi",
+    "currency_code": "GMD",
+    "currency_symbol": "D"
+  },
+  {
+    "country_name": "Haiti",
+    "country_code": "HT",
+    "phone_code": "+509",
+    "flag": "🇭🇹",
+    "currency": "Gourde",
+    "currency_code": "HTG",
+    "currency_symbol": "G"
+  },
+  {
+    "country_name": "Slovenia",
+    "country_code": "SI",
+    "phone_code": "+386",
+    "flag": "🇸🇮",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Martinique",
+    "country_code": "MQ",
+    "phone_code": null,
+    "flag": "🇲🇶",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Iceland",
+    "country_code": "IS",
+    "phone_code": "+354",
+    "flag": "🇮🇸",
+    "currency": "Krona",
+    "currency_code": "ISK",
+    "currency_symbol": "kr"
+  },
+  {
+    "country_name": "Belize",
+    "country_code": "BZ",
+    "phone_code": "+501",
+    "flag": "🇧🇿",
+    "currency": "Dollar",
+    "currency_code": "BZD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Djibouti",
+    "country_code": "DJ",
+    "phone_code": "+253",
+    "flag": "🇩🇯",
+    "currency": "Franc",
+    "currency_code": "DJF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Tunisia",
+    "country_code": "TN",
+    "phone_code": "+216",
+    "flag": "🇹🇳",
+    "currency": "Dinar",
+    "currency_code": "TND",
+    "currency_symbol": "د.ت"
+  },
+  {
+    "country_name": "Turks and Caicos Islands",
+    "country_code": "TC",
+    "phone_code": "+1-649",
+    "flag": "🇹🇨",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Liechtenstein",
+    "country_code": "LI",
+    "phone_code": "+423",
+    "flag": "🇱🇮",
+    "currency": "Franc",
+    "currency_code": "CHF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Burundi",
+    "country_code": "BI",
+    "phone_code": "+257",
+    "flag": "🇧🇮",
+    "currency": "Franc",
+    "currency_code": "BIF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Myanmar",
+    "country_code": "MM",
+    "phone_code": "+95",
+    "flag": "🇲🇲",
+    "currency": "Kyat",
+    "currency_code": "MMK",
+    "currency_symbol": "Ks"
+  },
+  {
+    "country_name": "Sint Maarten",
+    "country_code": "SX",
+    "phone_code": "+1-721",
+    "flag": "🇸🇽",
+    "currency": "Guilder",
+    "currency_code": "ANG",
+    "currency_symbol": "ƒ"
+  },
+  {
+    "country_name": "Hungary",
+    "country_code": "HU",
+    "phone_code": "+36",
+    "flag": "🇭🇺",
+    "currency": "Forint",
+    "currency_code": "HUF",
+    "currency_symbol": "Ft"
+  },
+  {
+    "country_name": "Netherlands Antilles",
+    "country_code": "AN",
+    "phone_code": "+599",
+    "flag": null,
+    "currency": "Guilder",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Netherlands",
+    "country_code": "NL",
+    "phone_code": "+31",
+    "flag": "🇳🇱",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Heard Island and McDonald Islands",
+    "country_code": "HM",
+    "phone_code": null,
+    "flag": "🇭🇲",
+    "currency": null,
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Nepal",
+    "country_code": "NP",
+    "phone_code": "+977",
+    "flag": "🇳🇵",
+    "currency": "Rupee",
+    "currency_code": "NPR",
+    "currency_symbol": "₨"
+  },
+  {
+    "country_name": "Thailand",
+    "country_code": "TH",
+    "phone_code": "+66",
+    "flag": "🇹🇭",
+    "currency": "Baht",
+    "currency_code": "THB",
+    "currency_symbol": "฿"
+  },
+  {
+    "country_name": "Marshall Islands",
+    "country_code": "MH",
+    "phone_code": "+692",
+    "flag": "🇲🇭",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Timor-Leste",
+    "country_code": "TL",
+    "phone_code": null,
+    "flag": "🇹🇱",
+    "currency": "United States dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Iran",
+    "country_code": "IR",
+    "phone_code": "+98",
+    "flag": "🇮🇷",
+    "currency": "Rial",
+    "currency_code": "IRR",
+    "currency_symbol": "﷼"
+  },
+  {
+    "country_name": "Bermuda",
+    "country_code": "BM",
+    "phone_code": "+1-441",
+    "flag": "🇧🇲",
+    "currency": "Dollar",
+    "currency_code": "BMD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "North Macedonia",
+    "country_code": "MK",
+    "phone_code": null,
+    "flag": "🇲🇰",
+    "currency": "denar",
+    "currency_code": "MKD",
+    "currency_symbol": "den"
+  },
+  {
+    "country_name": "Isle of Man",
+    "country_code": "IM",
+    "phone_code": "+44-1624",
+    "flag": "🇮🇲",
+    "currency": "Pound",
+    "currency_code": "GBP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Palestine",
+    "country_code": "PS",
+    "phone_code": "+970",
+    "flag": "🇵🇸",
+    "currency": "Shekel",
+    "currency_code": "EGP",
+    "currency_symbol": "E£"
+  },
+  {
+    "country_name": "Russia",
+    "country_code": "RU",
+    "phone_code": "+7",
+    "flag": "🇷🇺",
+    "currency": "Ruble",
+    "currency_code": "RUB",
+    "currency_symbol": "₽"
+  },
+  {
+    "country_name": "Papua New Guinea",
+    "country_code": "PG",
+    "phone_code": "+675",
+    "flag": "🇵🇬",
+    "currency": "Kina",
+    "currency_code": "PGK",
+    "currency_symbol": "K"
+  },
+  {
+    "country_name": "Saint Vincent and the Grenadines",
+    "country_code": "VC",
+    "phone_code": "+1-784",
+    "flag": "🇻🇨",
+    "currency": "Dollar",
+    "currency_code": "XCD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Panama",
+    "country_code": "PA",
+    "phone_code": "+507",
+    "flag": "🇵🇦",
+    "currency": "Balboa",
+    "currency_code": "PAB",
+    "currency_symbol": "B/."
+  },
+  {
+    "country_name": "Republic of the Congo",
+    "country_code": "CG",
+    "phone_code": "+242",
+    "flag": "🇨🇬",
+    "currency": "Franc",
+    "currency_code": "XAF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "United States Minor Outlying Islands",
+    "country_code": "UM",
+    "phone_code": null,
+    "flag": "🇺🇲",
+    "currency": "United States dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Tajikistan",
+    "country_code": "TJ",
+    "phone_code": "+992",
+    "flag": "🇹🇯",
+    "currency": "Somoni",
+    "currency_code": "TJS",
+    "currency_symbol": "ЅМ"
+  },
+  {
+    "country_name": "American Samoa",
+    "country_code": "AS",
+    "phone_code": "+1-684",
+    "flag": "🇦🇸",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Singapore",
+    "country_code": "SG",
+    "phone_code": "+65",
+    "flag": "🇸🇬",
+    "currency": "Dollar",
+    "currency_code": "SGD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Saint Pierre and Miquelon",
+    "country_code": "PM",
+    "phone_code": "+508",
+    "flag": "🇵🇲",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Saint Kitts and Nevis",
+    "country_code": "KN",
+    "phone_code": "+1-869",
+    "flag": "🇰🇳",
+    "currency": "Dollar",
+    "currency_code": "XCD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Kazakhstan",
+    "country_code": "KZ",
+    "phone_code": "+7",
+    "flag": "🇰🇿",
+    "currency": "Tenge",
+    "currency_code": "KZT",
+    "currency_symbol": "₸"
+  },
+  {
+    "country_name": "Chile",
+    "country_code": "CL",
+    "phone_code": "+56",
+    "flag": "🇨🇱",
+    "currency": "Peso",
+    "currency_code": "CLP",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Syria",
+    "country_code": "SY",
+    "phone_code": "+963",
+    "flag": "🇸🇾",
+    "currency": "Pound",
+    "currency_code": "SYP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Belgium",
+    "country_code": "BE",
+    "phone_code": "+32",
+    "flag": "🇧🇪",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Jamaica",
+    "country_code": "JM",
+    "phone_code": "+1-876",
+    "flag": "🇯🇲",
+    "currency": "Dollar",
+    "currency_code": "JMD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Nicaragua",
+    "country_code": "NI",
+    "phone_code": "+505",
+    "flag": "🇳🇮",
+    "currency": "Cordoba",
+    "currency_code": "NIO",
+    "currency_symbol": "C$"
+  },
+  {
+    "country_name": "United Arab Emirates",
+    "country_code": "AE",
+    "phone_code": "+971",
+    "flag": "🇦🇪",
+    "currency": "Dirham",
+    "currency_code": "AED",
+    "currency_symbol": "د.إ"
+  },
+  {
+    "country_name": "Zambia",
+    "country_code": "ZM",
+    "phone_code": "+260",
+    "flag": "🇿🇲",
+    "currency": "Kwacha",
+    "currency_code": "ZMW",
+    "currency_symbol": "ZK"
+  },
+  {
+    "country_name": "Kuwait",
+    "country_code": "KW",
+    "phone_code": "+965",
+    "flag": "🇰🇼",
+    "currency": "Dinar",
+    "currency_code": "KWD",
+    "currency_symbol": "د.ك"
+  },
+  {
+    "country_name": "Micronesia",
+    "country_code": "FM",
+    "phone_code": "+691",
+    "flag": "🇫🇲",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "New Zealand",
+    "country_code": "NZ",
+    "phone_code": "+64",
+    "flag": "🇳🇿",
+    "currency": "Dollar",
+    "currency_code": "NZD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "São Tomé and Príncipe",
+    "country_code": "ST",
+    "phone_code": null,
+    "flag": "🇸🇹",
+    "currency": "São Tomé and Príncipe dobra",
+    "currency_code": "STN",
+    "currency_symbol": "Db"
+  },
+  {
+    "country_name": "Austria",
+    "country_code": "AT",
+    "phone_code": "+43",
+    "flag": "🇦🇹",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Saint Helena",
+    "country_code": "SH",
+    "phone_code": "+290",
+    "flag": null,
+    "currency": "Pound",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Pitcairn",
+    "country_code": "PN",
+    "phone_code": "+64",
+    "flag": null,
+    "currency": "Dollar",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Caribbean Netherlands",
+    "country_code": "BQ",
+    "phone_code": null,
+    "flag": "🇧🇶",
+    "currency": "United States dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Gibraltar",
+    "country_code": "GI",
+    "phone_code": "+350",
+    "flag": "🇬🇮",
+    "currency": "Pound",
+    "currency_code": "GIP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Slovakia",
+    "country_code": "SK",
+    "phone_code": "+421",
+    "flag": "🇸🇰",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "East Timor",
+    "country_code": "TL",
+    "phone_code": "+670",
+    "flag": null,
+    "currency": "Dollar",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Iraq",
+    "country_code": "IQ",
+    "phone_code": "+964",
+    "flag": "🇮🇶",
+    "currency": "Dinar",
+    "currency_code": "IQD",
+    "currency_symbol": "ع.د"
+  },
+  {
+    "country_name": "Botswana",
+    "country_code": "BW",
+    "phone_code": "+267",
+    "flag": "🇧🇼",
+    "currency": "Pula",
+    "currency_code": "BWP",
+    "currency_symbol": "P"
+  },
+  {
+    "country_name": "Costa Rica",
+    "country_code": "CR",
+    "phone_code": "+506",
+    "flag": "🇨🇷",
+    "currency": "Colon",
+    "currency_code": "CRC",
+    "currency_symbol": "₡"
+  },
+  {
+    "country_name": "Vietnam",
+    "country_code": "VN",
+    "phone_code": "+84",
+    "flag": "🇻🇳",
+    "currency": "Dong",
+    "currency_code": "VND",
+    "currency_symbol": "₫"
+  },
+  {
+    "country_name": "Libya",
+    "country_code": "LY",
+    "phone_code": "+218",
+    "flag": "🇱🇾",
+    "currency": "Dinar",
+    "currency_code": "LYD",
+    "currency_symbol": "ل.د"
+  },
+  {
+    "country_name": "Bangladesh",
+    "country_code": "BD",
+    "phone_code": "+880",
+    "flag": "🇧🇩",
+    "currency": "Taka",
+    "currency_code": "BDT",
+    "currency_symbol": "৳"
+  },
+  {
+    "country_name": "French Southern and Antarctic Lands",
+    "country_code": "TF",
+    "phone_code": null,
+    "flag": "🇹🇫",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Sweden",
+    "country_code": "SE",
+    "phone_code": "+46",
+    "flag": "🇸🇪",
+    "currency": "Krona",
+    "currency_code": "SEK",
+    "currency_symbol": "kr"
+  },
+  {
+    "country_name": "Norfolk Island",
+    "country_code": "NF",
+    "phone_code": null,
+    "flag": "🇳🇫",
+    "currency": "Australian dollar",
+    "currency_code": "AUD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Pakistan",
+    "country_code": "PK",
+    "phone_code": "+92",
+    "flag": "🇵🇰",
+    "currency": "Rupee",
+    "currency_code": "PKR",
+    "currency_symbol": "₨"
+  },
+  {
+    "country_name": "Rwanda",
+    "country_code": "RW",
+    "phone_code": "+250",
+    "flag": "🇷🇼",
+    "currency": "Franc",
+    "currency_code": "RWF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Nauru",
+    "country_code": "NR",
+    "phone_code": "+674",
+    "flag": "🇳🇷",
+    "currency": "Dollar",
+    "currency_code": "AUD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Burkina Faso",
+    "country_code": "BF",
+    "phone_code": "+226",
+    "flag": "🇧🇫",
+    "currency": "Franc",
+    "currency_code": "XOF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Niger",
+    "country_code": "NE",
+    "phone_code": "+227",
+    "flag": "🇳🇪",
+    "currency": "Franc",
+    "currency_code": "XOF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "United Kingdom",
+    "country_code": "GB",
+    "phone_code": "+44",
+    "flag": "🇬🇧",
+    "currency": "Pound",
+    "currency_code": "GBP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Ivory Coast",
+    "country_code": "CI",
+    "phone_code": "+225",
+    "flag": "🇨🇮",
+    "currency": "Franc",
+    "currency_code": "XOF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "DR Congo",
+    "country_code": "CD",
+    "phone_code": null,
+    "flag": "🇨🇩",
+    "currency": "Congolese franc",
+    "currency_code": "CDF",
+    "currency_symbol": "FC"
+  },
+  {
+    "country_name": "Antigua and Barbuda",
+    "country_code": "AG",
+    "phone_code": "+1-268",
+    "flag": "🇦🇬",
+    "currency": "Dollar",
+    "currency_code": "XCD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Somalia",
+    "country_code": "SO",
+    "phone_code": "+252",
+    "flag": "🇸🇴",
+    "currency": "Shilling",
+    "currency_code": "SOS",
+    "currency_symbol": "Sh"
+  },
+  {
+    "country_name": "Finland",
+    "country_code": "FI",
+    "phone_code": "+358",
+    "flag": "🇫🇮",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Bahamas",
+    "country_code": "BS",
+    "phone_code": "+1-242",
+    "flag": "🇧🇸",
+    "currency": "Dollar",
+    "currency_code": "BSD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Lithuania",
+    "country_code": "LT",
+    "phone_code": "+370",
+    "flag": "🇱🇹",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "South Africa",
+    "country_code": "ZA",
+    "phone_code": "+27",
+    "flag": "🇿🇦",
+    "currency": "Rand",
+    "currency_code": "ZAR",
+    "currency_symbol": "R"
+  },
+  {
+    "country_name": "Svalbard and Jan Mayen",
+    "country_code": "SJ",
+    "phone_code": "+47",
+    "flag": "🇸🇯",
+    "currency": "Krone",
+    "currency_code": "NOK",
+    "currency_symbol": "kr"
+  },
+  {
+    "country_name": "Western Sahara",
+    "country_code": "EH",
+    "phone_code": "+212",
+    "flag": "🇪🇭",
+    "currency": "Dirham",
+    "currency_code": "DZD",
+    "currency_symbol": "دج"
+  },
+  {
+    "country_name": "Kyrgyzstan",
+    "country_code": "KG",
+    "phone_code": "+996",
+    "flag": "🇰🇬",
+    "currency": "Som",
+    "currency_code": "KGS",
+    "currency_symbol": "с"
+  },
+  {
+    "country_name": "Macau",
+    "country_code": "MO",
+    "phone_code": "+853",
+    "flag": "🇲🇴",
+    "currency": "Pataca",
+    "currency_code": "MOP",
+    "currency_symbol": "P"
+  },
+  {
+    "country_name": "Ghana",
+    "country_code": "GH",
+    "phone_code": "+233",
+    "flag": "🇬🇭",
+    "currency": "Cedi",
+    "currency_code": "GHS",
+    "currency_symbol": "₵"
+  },
+  {
+    "country_name": "Lesotho",
+    "country_code": "LS",
+    "phone_code": "+266",
+    "flag": "🇱🇸",
+    "currency": "Loti",
+    "currency_code": "LSL",
+    "currency_symbol": "L"
+  },
+  {
+    "country_name": "Bahrain",
+    "country_code": "BH",
+    "phone_code": "+973",
+    "flag": "🇧🇭",
+    "currency": "Dinar",
+    "currency_code": "BHD",
+    "currency_symbol": ".د.ب"
+  },
+  {
+    "country_name": "Tanzania",
+    "country_code": "TZ",
+    "phone_code": "+255",
+    "flag": "🇹🇿",
+    "currency": "Shilling",
+    "currency_code": "TZS",
+    "currency_symbol": "Sh"
+  },
+  {
+    "country_name": "China",
+    "country_code": "CN",
+    "phone_code": "+86",
+    "flag": "🇨🇳",
+    "currency": "Yuan Renminbi",
+    "currency_code": "CNY",
+    "currency_symbol": "¥"
+  },
+  {
+    "country_name": "Montenegro",
+    "country_code": "ME",
+    "phone_code": "+382",
+    "flag": "🇲🇪",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Laos",
+    "country_code": "LA",
+    "phone_code": "+856",
+    "flag": "🇱🇦",
+    "currency": "Kip",
+    "currency_code": "LAK",
+    "currency_symbol": "₭"
+  },
+  {
+    "country_name": "Bhutan",
+    "country_code": "BT",
+    "phone_code": "+975",
+    "flag": "🇧🇹",
+    "currency": "Ngultrum",
+    "currency_code": "BTN",
+    "currency_symbol": "Nu."
+  },
+  {
+    "country_name": "South Korea",
+    "country_code": "KR",
+    "phone_code": "+82",
+    "flag": "🇰🇷",
+    "currency": "Won",
+    "currency_code": "KRW",
+    "currency_symbol": "₩"
+  },
+  {
+    "country_name": "Kiribati",
+    "country_code": "KI",
+    "phone_code": "+686",
+    "flag": "🇰🇮",
+    "currency": "Dollar",
+    "currency_code": "AUD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Senegal",
+    "country_code": "SN",
+    "phone_code": "+221",
+    "flag": "🇸🇳",
+    "currency": "Franc",
+    "currency_code": "XOF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Turkmenistan",
+    "country_code": "TM",
+    "phone_code": "+993",
+    "flag": "🇹🇲",
+    "currency": "Manat",
+    "currency_code": "TMT",
+    "currency_symbol": "m"
+  },
+  {
+    "country_name": "Italy",
+    "country_code": "IT",
+    "phone_code": "+39",
+    "flag": "🇮🇹",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Israel",
+    "country_code": "IL",
+    "phone_code": "+972",
+    "flag": "🇮🇱",
+    "currency": "Shekel",
+    "currency_code": "ILS",
+    "currency_symbol": "₪"
+  },
+  {
+    "country_name": "New Caledonia",
+    "country_code": "NC",
+    "phone_code": "+687",
+    "flag": "🇳🇨",
+    "currency": "Franc",
+    "currency_code": "XPF",
+    "currency_symbol": "₣"
+  },
+  {
+    "country_name": "Armenia",
+    "country_code": "AM",
+    "phone_code": "+374",
+    "flag": "🇦🇲",
+    "currency": "Dram",
+    "currency_code": "AMD",
+    "currency_symbol": "֏"
+  },
+  {
+    "country_name": "Curacao",
+    "country_code": "CW",
+    "phone_code": "+599",
+    "flag": null,
+    "currency": "Guilder",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Eswatini",
+    "country_code": "SZ",
+    "phone_code": null,
+    "flag": "🇸🇿",
+    "currency": "Swazi lilangeni",
+    "currency_code": "SZL",
+    "currency_symbol": "L"
+  },
+  {
+    "country_name": "United States Virgin Islands",
+    "country_code": "VI",
+    "phone_code": null,
+    "flag": "🇻🇮",
+    "currency": "United States dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Paraguay",
+    "country_code": "PY",
+    "phone_code": "+595",
+    "flag": "🇵🇾",
+    "currency": "Guarani",
+    "currency_code": "PYG",
+    "currency_symbol": "₲"
+  },
+  {
+    "country_name": "Uzbekistan",
+    "country_code": "UZ",
+    "phone_code": "+998",
+    "flag": "🇺🇿",
+    "currency": "Som",
+    "currency_code": "UZS",
+    "currency_symbol": "so'm"
+  },
+  {
+    "country_name": "Anguilla",
+    "country_code": "AI",
+    "phone_code": "+1-264",
+    "flag": "🇦🇮",
+    "currency": "Dollar",
+    "currency_code": "XCD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Saint Barthelemy",
+    "country_code": "BL",
+    "phone_code": "+590",
+    "flag": null,
+    "currency": "Euro",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Palau",
+    "country_code": "PW",
+    "phone_code": "+680",
+    "flag": "🇵🇼",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Namibia",
+    "country_code": "NA",
+    "phone_code": "+264",
+    "flag": "🇳🇦",
+    "currency": "Dollar",
+    "currency_code": "NAD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Mayotte",
+    "country_code": "YT",
+    "phone_code": "+262",
+    "flag": "🇾🇹",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Venezuela",
+    "country_code": "VE",
+    "phone_code": "+58",
+    "flag": "🇻🇪",
+    "currency": "Bolivar",
+    "currency_code": "VES",
+    "currency_symbol": "Bs.S."
+  },
+  {
+    "country_name": "Morocco",
+    "country_code": "MA",
+    "phone_code": "+212",
+    "flag": "🇲🇦",
+    "currency": "Dirham",
+    "currency_code": "MAD",
+    "currency_symbol": "د.م."
+  },
+  {
+    "country_name": "Saint Helena, Ascension and Tristan da Cunha",
+    "country_code": "SH",
+    "phone_code": null,
+    "flag": "🇸🇭",
+    "currency": "Pound sterling",
+    "currency_code": "GBP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Democratic Republic of the Congo",
+    "country_code": "CD",
+    "phone_code": "+243",
+    "flag": null,
+    "currency": "Franc",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Greece",
+    "country_code": "GR",
+    "phone_code": "+30",
+    "flag": "🇬🇷",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Greenland",
+    "country_code": "GL",
+    "phone_code": "+299",
+    "flag": "🇬🇱",
+    "currency": "Krone",
+    "currency_code": "DKK",
+    "currency_symbol": "kr."
+  },
+  {
+    "country_name": "Moldova",
+    "country_code": "MD",
+    "phone_code": "+373",
+    "flag": "🇲🇩",
+    "currency": "Leu",
+    "currency_code": "MDL",
+    "currency_symbol": "L"
+  },
+  {
+    "country_name": "Bosnia and Herzegovina",
+    "country_code": "BA",
+    "phone_code": "+387",
+    "flag": "🇧🇦",
+    "currency": "Marka",
+    "currency_code": "BAM",
+    "currency_symbol": "KM"
+  },
+  {
+    "country_name": "Albania",
+    "country_code": "AL",
+    "phone_code": "+355",
+    "flag": "🇦🇱",
+    "currency": "Lek",
+    "currency_code": "ALL",
+    "currency_symbol": "L"
+  },
+  {
+    "country_name": "Sri Lanka",
+    "country_code": "LK",
+    "phone_code": "+94",
+    "flag": "🇱🇰",
+    "currency": "Rupee",
+    "currency_code": "LKR",
+    "currency_symbol": "Rs  රු"
+  },
+  {
+    "country_name": "Romania",
+    "country_code": "RO",
+    "phone_code": "+40",
+    "flag": "🇷🇴",
+    "currency": "Leu",
+    "currency_code": "RON",
+    "currency_symbol": "lei"
+  },
+  {
+    "country_name": "Cambodia",
+    "country_code": "KH",
+    "phone_code": "+855",
+    "flag": "🇰🇭",
+    "currency": "Riels",
+    "currency_code": "KHR",
+    "currency_symbol": "៛"
+  },
+  {
+    "country_name": "Malaysia",
+    "country_code": "MY",
+    "phone_code": "+60",
+    "flag": "🇲🇾",
+    "currency": "Ringgit",
+    "currency_code": "MYR",
+    "currency_symbol": "RM"
+  },
+  {
+    "country_name": "Mozambique",
+    "country_code": "MZ",
+    "phone_code": "+258",
+    "flag": "🇲🇿",
+    "currency": "Metical",
+    "currency_code": "MZN",
+    "currency_symbol": "MT"
+  },
+  {
+    "country_name": "Tonga",
+    "country_code": "TO",
+    "phone_code": "+676",
+    "flag": "🇹🇴",
+    "currency": "Pa'anga",
+    "currency_code": "TOP",
+    "currency_symbol": "T$"
+  },
+  {
+    "country_name": "India",
+    "country_code": "IN",
+    "phone_code": "+91",
+    "flag": "🇮🇳",
+    "currency": "Rupee",
+    "currency_code": "INR",
+    "currency_symbol": "₹"
+  },
+  {
+    "country_name": "Azerbaijan",
+    "country_code": "AZ",
+    "phone_code": "+994",
+    "flag": "🇦🇿",
+    "currency": "Manat",
+    "currency_code": "AZN",
+    "currency_symbol": "₼"
+  },
+  {
+    "country_name": "Vatican",
+    "country_code": "VA",
+    "phone_code": "+379",
+    "flag": null,
+    "currency": "Euro",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "British Virgin Islands",
+    "country_code": "VG",
+    "phone_code": "+1-284",
+    "flag": "🇻🇬",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Niue",
+    "country_code": "NU",
+    "phone_code": "+683",
+    "flag": "🇳🇺",
+    "currency": "Dollar",
+    "currency_code": "NZD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Bouvet Island",
+    "country_code": "BV",
+    "phone_code": null,
+    "flag": "🇧🇻",
+    "currency": null,
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Christmas Island",
+    "country_code": "CX",
+    "phone_code": "+61",
+    "flag": "🇨🇽",
+    "currency": "Dollar",
+    "currency_code": "AUD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Switzerland",
+    "country_code": "CH",
+    "phone_code": "+41",
+    "flag": "🇨🇭",
+    "currency": "Franc",
+    "currency_code": "CHF",
+    "currency_symbol": "Fr."
+  },
+  {
+    "country_name": "Cocos (Keeling) Islands",
+    "country_code": "CC",
+    "phone_code": null,
+    "flag": "🇨🇨",
+    "currency": "Australian dollar",
+    "currency_code": "AUD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "North Korea",
+    "country_code": "KP",
+    "phone_code": "+850",
+    "flag": "🇰🇵",
+    "currency": "Won",
+    "currency_code": "KPW",
+    "currency_symbol": "₩"
+  },
+  {
+    "country_name": "Poland",
+    "country_code": "PL",
+    "phone_code": "+48",
+    "flag": "🇵🇱",
+    "currency": "Zloty",
+    "currency_code": "PLN",
+    "currency_symbol": "zł"
+  },
+  {
+    "country_name": "French Guiana",
+    "country_code": "GF",
+    "phone_code": null,
+    "flag": "🇬🇫",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Solomon Islands",
+    "country_code": "SB",
+    "phone_code": "+677",
+    "flag": "🇸🇧",
+    "currency": "Dollar",
+    "currency_code": "SBD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Belarus",
+    "country_code": "BY",
+    "phone_code": "+375",
+    "flag": "🇧🇾",
+    "currency": "Ruble",
+    "currency_code": "BYN",
+    "currency_symbol": "Br"
+  },
+  {
+    "country_name": "Algeria",
+    "country_code": "DZ",
+    "phone_code": "+213",
+    "flag": "🇩🇿",
+    "currency": "Dinar",
+    "currency_code": "DZD",
+    "currency_symbol": "د.ج"
+  },
+  {
+    "country_name": "Mongolia",
+    "country_code": "MN",
+    "phone_code": "+976",
+    "flag": "🇲🇳",
+    "currency": "Tugrik",
+    "currency_code": "MNT",
+    "currency_symbol": "₮"
+  },
+  {
+    "country_name": "Honduras",
+    "country_code": "HN",
+    "phone_code": "+504",
+    "flag": "🇭🇳",
+    "currency": "Lempira",
+    "currency_code": "HNL",
+    "currency_symbol": "L"
+  },
+  {
+    "country_name": "Sao Tome and Principe",
+    "country_code": "ST",
+    "phone_code": "+239",
+    "flag": null,
+    "currency": "Dobra",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Luxembourg",
+    "country_code": "LU",
+    "phone_code": "+352",
+    "flag": "🇱🇺",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Guinea",
+    "country_code": "GN",
+    "phone_code": "+224",
+    "flag": "🇬🇳",
+    "currency": "Franc",
+    "currency_code": "GNF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Sierra Leone",
+    "country_code": "SL",
+    "phone_code": "+232",
+    "flag": "🇸🇱",
+    "currency": "Leone",
+    "currency_code": "SLE",
+    "currency_symbol": "Le"
+  },
+  {
+    "country_name": "Taiwan",
+    "country_code": "TW",
+    "phone_code": "+886",
+    "flag": "🇹🇼",
+    "currency": "Dollar",
+    "currency_code": "TWD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Mali",
+    "country_code": "ML",
+    "phone_code": "+223",
+    "flag": "🇲🇱",
+    "currency": "Franc",
+    "currency_code": "XOF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Saudi Arabia",
+    "country_code": "SA",
+    "phone_code": "+966",
+    "flag": "🇸🇦",
+    "currency": "Rial",
+    "currency_code": "SAR",
+    "currency_symbol": "ر.س"
+  },
+  {
+    "country_name": "Swaziland",
+    "country_code": "SZ",
+    "phone_code": "+268",
+    "flag": null,
+    "currency": "Lilangeni",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Norway",
+    "country_code": "NO",
+    "phone_code": "+47",
+    "flag": "🇳🇴",
+    "currency": "Krone",
+    "currency_code": "NOK",
+    "currency_symbol": "kr"
+  },
+  {
+    "country_name": "Réunion",
+    "country_code": "RE",
+    "phone_code": null,
+    "flag": "🇷🇪",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Germany",
+    "country_code": "DE",
+    "phone_code": "+49",
+    "flag": "🇩🇪",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Uganda",
+    "country_code": "UG",
+    "phone_code": "+256",
+    "flag": "🇺🇬",
+    "currency": "Shilling",
+    "currency_code": "UGX",
+    "currency_symbol": "Sh"
+  },
+  {
+    "country_name": "Liberia",
+    "country_code": "LR",
+    "phone_code": "+231",
+    "flag": "🇱🇷",
+    "currency": "Dollar",
+    "currency_code": "LRD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Ukraine",
+    "country_code": "UA",
+    "phone_code": "+380",
+    "flag": "🇺🇦",
+    "currency": "Hryvnia",
+    "currency_code": "UAH",
+    "currency_symbol": "₴"
+  },
+  {
+    "country_name": "Latvia",
+    "country_code": "LV",
+    "phone_code": "+371",
+    "flag": "🇱🇻",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Montserrat",
+    "country_code": "MS",
+    "phone_code": "+1-664",
+    "flag": "🇲🇸",
+    "currency": "Dollar",
+    "currency_code": "XCD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Qatar",
+    "country_code": "QA",
+    "phone_code": "+974",
+    "flag": "🇶🇦",
+    "currency": "Rial",
+    "currency_code": "QAR",
+    "currency_symbol": "ر.ق"
+  },
+  {
+    "country_name": "Oman",
+    "country_code": "OM",
+    "phone_code": "+968",
+    "flag": "🇴🇲",
+    "currency": "Rial",
+    "currency_code": "OMR",
+    "currency_symbol": "ر.ع."
+  },
+  {
+    "country_name": "Estonia",
+    "country_code": "EE",
+    "phone_code": "+372",
+    "flag": "🇪🇪",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Comoros",
+    "country_code": "KM",
+    "phone_code": "+269",
+    "flag": "🇰🇲",
+    "currency": "Franc",
+    "currency_code": "KMF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Peru",
+    "country_code": "PE",
+    "phone_code": "+51",
+    "flag": "🇵🇪",
+    "currency": "Sol",
+    "currency_code": "PEN",
+    "currency_symbol": "S/ "
+  },
+  {
+    "country_name": "Chad",
+    "country_code": "TD",
+    "phone_code": "+235",
+    "flag": "🇹🇩",
+    "currency": "Franc",
+    "currency_code": "XAF",
+    "currency_symbol": "Fr"
+  },
+  {
+    "country_name": "Jersey",
+    "country_code": "JE",
+    "phone_code": "+44-1534",
+    "flag": "🇯🇪",
+    "currency": "Pound",
+    "currency_code": "GBP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Cocos Islands",
+    "country_code": "CC",
+    "phone_code": "+61",
+    "flag": null,
+    "currency": "Dollar",
+    "currency_code": null,
+    "currency_symbol": null
+  },
+  {
+    "country_name": "Dominica",
+    "country_code": "DM",
+    "phone_code": "+1-767",
+    "flag": "🇩🇲",
+    "currency": "Dollar",
+    "currency_code": "XCD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Northern Mariana Islands",
+    "country_code": "MP",
+    "phone_code": "+1-670",
+    "flag": "🇲🇵",
+    "currency": "Dollar",
+    "currency_code": "USD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Kosovo",
+    "country_code": "XK",
+    "phone_code": "+383",
+    "flag": "🇽🇰",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Egypt",
+    "country_code": "EG",
+    "phone_code": "+20",
+    "flag": "🇪🇬",
+    "currency": "Pound",
+    "currency_code": "EGP",
+    "currency_symbol": "£"
+  },
+  {
+    "country_name": "Curaçao",
+    "country_code": "CW",
+    "phone_code": null,
+    "flag": "🇨🇼",
+    "currency": "Netherlands Antillean guilder",
+    "currency_code": "ANG",
+    "currency_symbol": "ƒ"
+  },
+  {
+    "country_name": "French Polynesia",
+    "country_code": "PF",
+    "phone_code": "+689",
+    "flag": "🇵🇫",
+    "currency": "Franc",
+    "currency_code": "XPF",
+    "currency_symbol": "₣"
+  },
+  {
+    "country_name": "Bolivia",
+    "country_code": "BO",
+    "phone_code": "+591",
+    "flag": "🇧🇴",
+    "currency": "Boliviano",
+    "currency_code": "BOB",
+    "currency_symbol": "Bs."
+  },
+  {
+    "country_name": "Croatia",
+    "country_code": "HR",
+    "phone_code": "+385",
+    "flag": "🇭🇷",
+    "currency": "Kuna",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Ireland",
+    "country_code": "IE",
+    "phone_code": "+353",
+    "flag": "🇮🇪",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Faroe Islands",
+    "country_code": "FO",
+    "phone_code": "+298",
+    "flag": "🇫🇴",
+    "currency": "Krone",
+    "currency_code": "DKK",
+    "currency_symbol": "kr"
+  },
+  {
+    "country_name": "Serbia",
+    "country_code": "RS",
+    "phone_code": "+381",
+    "flag": "🇷🇸",
+    "currency": "Dinar",
+    "currency_code": "RSD",
+    "currency_symbol": "дин."
+  },
+  {
+    "country_name": "Andorra",
+    "country_code": "AD",
+    "phone_code": "+376",
+    "flag": "🇦🇩",
+    "currency": "Euro",
+    "currency_code": "EUR",
+    "currency_symbol": "€"
+  },
+  {
+    "country_name": "Malawi",
+    "country_code": "MW",
+    "phone_code": "+265",
+    "flag": "🇲🇼",
+    "currency": "Kwacha",
+    "currency_code": "MWK",
+    "currency_symbol": "MK"
+  },
+  {
+    "country_name": "Seychelles",
+    "country_code": "SC",
+    "phone_code": "+248",
+    "flag": "🇸🇨",
+    "currency": "Rupee",
+    "currency_code": "SCR",
+    "currency_symbol": "₨"
+  },
+  {
+    "country_name": "Czechia",
+    "country_code": "CZ",
+    "phone_code": null,
+    "flag": "🇨🇿",
+    "currency": "Czech koruna",
+    "currency_code": "CZK",
+    "currency_symbol": "Kč"
+  },
+  {
+    "country_name": "Fiji",
+    "country_code": "FJ",
+    "phone_code": "+679",
+    "flag": "🇫🇯",
+    "currency": "Dollar",
+    "currency_code": "FJD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Suriname",
+    "country_code": "SR",
+    "phone_code": "+597",
+    "flag": "🇸🇷",
+    "currency": "Dollar",
+    "currency_code": "SRD",
+    "currency_symbol": "$"
+  },
+  {
+    "country_name": "Georgia",
+    "country_code": "GE",
+    "phone_code": "+995",
+    "flag": "🇬🇪",
+    "currency": "Lari",
+    "currency_code": "GEL",
+    "currency_symbol": "₾"
   }
 ]


### PR DESCRIPTION
- removed space between key
- followed snake_case

## Data Structure
Each country entry follows this format:
```json
{
  "country_name": "String",
  "country_code": "ISO String",
  "phone_code": "String with + prefix",
  "flag": "Unicode Flag Emoji",
  "currency": "Currency Name",
  "currency_code": "ISO Currency Code",
  "currency_symbol": "Currency Symbol"
}
```

## Validation
- All country codes follow ISO 3166-1 alpha-2 standard
- Currency codes follow ISO 4217 standard
- Phone codes include proper international prefix format
- Null values are explicitly set for missing data

## Use Cases
- International e-commerce platforms
- Phone number validation and formatting
- Currency conversion applications
- Country selection interfaces
- International shipping systems   